### PR TITLE
IJPL-214442: Introduce parallelism adjustment for coroutine dispatchers

### DIFF
--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -52,12 +52,32 @@ exceeding the parallelism limit would eliminate this (likely expected) side effe
 which results in a deadlock when there are no threads in a limited-thread dispatcher that are able to cancel the cancelling coroutines.
 We provide a user-visible function for parallelism compensation for arbitrary blocking operation.
 
+### Parallelism adjustment
+
+In addition to the compensation mechanism triggered automatically by `runBlockingWithParallelismCompensation`, it is
+sometimes necessary for a caller to directly adjust the parallelism limit of a dispatcher, for example, when pool is
+starved, it can be detected by external thread or coroutine, and it can temporarily increase parallelism limit.
+
+`tryAdjustParallelism` is a best-effort operation: it attempts to shift the effective parallelism limit by
+`parallelismDelta` (positive to increase, negative to decrease), but the actual adjustment applied may be less than
+requested, or zero. The function returns the actual delta that was applied.
+
+**Constraints for `Default` dispatcher:**
+- The parallelism limit cannot be decreased below the dispatcher's initial `corePoolSize`.
+- The number of outstanding increases is bounded by `MAX_OUTSTANDING_CPU_COMPENSATIONS` (configurable via a system
+  property). Attempts to exceed this bound return `0`.
+- Outstanding increases are automatically reclaimed on scheduler shutdown.
+
+**Constraints for `IO` dispatcher:**
+- The parallelism can not be decreased below the initial value
+
 ### API
 - `runBlockingWithParallelismCompensation` - an analogue of `runBlocking` which also compensates parallelism of the
   associated coroutine dispatcher when it decides to park the thread
 - `CoroutineDispatcher.softLimitedParallelism` – an analogue of `.limitedParallelism` which supports
   parallelism compensation
 - `runAndCompensateParallelism` - a wrapper for an arbitrary blocking operation that initiates parallelism compensation after deadline.
+- `CoroutineDispatcher.tryAdjustParallelism` - a method that allows to change parallelism limit for the dispatcher
 
 ## Asynchronous stack traces for flows in the IDEA debugger
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kotlin
-version=1.10.2-SNAPSHOT
+version=1.10.2-denis-130520
 group=org.jetbrains.intellij.deps.kotlinx
 kotlin_version=2.1.0
 # DO NOT rename this property without adapting kotlinx.train build chain:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kotlin
-version=1.10.2-denis-130520
+version=1.10.2-SNAPSHOT
 group=org.jetbrains.intellij.deps.kotlinx
 kotlin_version=2.1.0
 # DO NOT rename this property without adapting kotlinx.train build chain:

--- a/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
@@ -37,7 +37,7 @@ internal class NamedSoftParallelismDispatcher<D>(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun adjustParallelism(parallelism: Int) {
-        return dispatcher.adjustParallelism(parallelism)
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+        return dispatcher.tryAdjustParallelism(parallelismDelta)
     }
 }

--- a/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
@@ -36,4 +36,8 @@ internal class NamedSoftParallelismDispatcher<D>(
         parallelism.checkParallelism()
         return SoftLimitedDispatcher(this, parallelism, name)
     }
+
+    override fun adjustParallelism(parallelism: Int) {
+        return dispatcher.adjustParallelism(parallelism)
+    }
 }

--- a/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
@@ -37,7 +37,7 @@ internal class NamedSoftParallelismDispatcher<D>(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
         return dispatcher.tryAdjustParallelism(parallelismDelta)
     }
 }

--- a/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/NamedSoftParallelismDispatcher.kt
@@ -37,7 +37,7 @@ internal class NamedSoftParallelismDispatcher<D>(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
         return dispatcher.tryAdjustParallelism(parallelismDelta)
     }
 }

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -30,7 +30,7 @@ internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int, name: 
 
 internal fun CoroutineDispatcher.adjustParallelism(parallelism: Int) {
     if (this is SoftLimitedParallelism) {
-        this.adjustParallelism(parallelism)
+        return this.adjustParallelism(parallelism)
     }
     throw UnsupportedOperationException("CoroutineDispatcher.increaseParallelism cannot be applied to $this")
 }
@@ -74,10 +74,17 @@ internal class SoftLimitedDispatcher(
     }
 
     override fun adjustParallelism(parallelism: Int) {
-        if (totalParallelism + parallelism >= (hardParallelism ?: Int.MAX_VALUE)) {
+        if (totalParallelism + parallelism !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
             return
         }
-        (dispatcher as? SoftLimitedDispatcher ?: return).adjustParallelism(parallelism)
+        synchronized(workerAllocationLock) {
+            if (totalParallelism + parallelism !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
+                return // in case parallelism was adjusted by another thread
+            }
+            val permits = availablePermits.value
+            availablePermits.compareAndSet(permits, permits + parallelism)
+
+        }
     }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -88,6 +88,10 @@ internal class SoftLimitedDispatcher(
         }
         additionalSoftParallelism += delta
         availablePermits.addAndGet(delta)
+
+        // we need to signal scheduler that new worker can be allocated and can take tasks
+        // instead of exposing signaling API, let's just dispatch empty task
+        dispatch(EmptyCoroutineContext, { } )
         return parallelismDelta
     }
 

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -90,6 +90,7 @@ internal class SoftLimitedDispatcher(
 
         // we need to signal scheduler that new worker can be allocated and can take tasks
         // instead of exposing signaling API, let's just dispatch empty task
+        // It doesn't make sense to wake up more workers than there is tasks in queue
         repeat(parallelismDelta.coerceIn(0, queue.size)) {
             dispatch(EmptyCoroutineContext, { } )
         }

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -57,7 +57,7 @@ internal fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Byte): B
 internal class SoftLimitedDispatcher(
     private val dispatcher: CoroutineDispatcher,
     parallelism: Int,
-    private val name: String?,
+    private val name: String?
 ) : CoroutineDispatcher(), Delay by (dispatcher as? Delay ?: DefaultDelay), SoftLimitedParallelism {
     private val initialParallelism = parallelism
     private val additionalSoftParallelism = atomic(0)

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -14,6 +14,7 @@ import kotlin.coroutines.*
  */
 internal interface SoftLimitedParallelism {
     fun softLimitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher
+    fun adjustParallelism(parallelism: Int)
 }
 
 /**
@@ -25,6 +26,13 @@ internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int, name: 
     }
     // SoftLimitedDispatcher cannot be used on top of LimitedDispatcher, because the latter doesn't propagate compensation requests
     throw UnsupportedOperationException("CoroutineDispatcher.softLimitedParallelism cannot be applied to $this")
+}
+
+internal fun CoroutineDispatcher.adjustParallelism(parallelism: Int) {
+    if (this is SoftLimitedParallelism) {
+        this.adjustParallelism(parallelism)
+    }
+    throw UnsupportedOperationException("CoroutineDispatcher.increaseParallelism cannot be applied to $this")
 }
 
 /**
@@ -39,15 +47,21 @@ internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int, name: 
 internal class SoftLimitedDispatcher(
     private val dispatcher: CoroutineDispatcher,
     parallelism: Int,
-    private val name: String?
+    private val name: String?,
+    private val hardParallelism: Int? = null
 ) : CoroutineDispatcher(), Delay by (dispatcher as? Delay ?: DefaultDelay), SoftLimitedParallelism {
     private val initialParallelism = parallelism
+    private val additionalSoftParallelism = 0
     // `parallelism limit - runningWorkers`; may be < 0 if decompensation is expected
     private val availablePermits = atomic(parallelism)
 
     private val queue = LockFreeTaskQueue<Runnable>(singleConsumer = false)
 
     private val workerAllocationLock = SynchronizedObject()
+
+    // totalParallelism doesn't detect if parallelism was compensated for a specific thread
+    private val totalParallelism
+        get() = initialParallelism + additionalSoftParallelism
 
     override fun limitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher {
         return super.limitedParallelism(parallelism, name)
@@ -57,6 +71,13 @@ internal class SoftLimitedDispatcher(
         parallelism.checkParallelism()
         if (parallelism >= initialParallelism) return namedOrThis(name)
         return SoftLimitedDispatcher(this, parallelism, name)
+    }
+
+    override fun adjustParallelism(parallelism: Int) {
+        if (totalParallelism + parallelism >= (hardParallelism ?: Int.MAX_VALUE)) {
+            return
+        }
+        (dispatcher as? SoftLimitedDispatcher ?: return).adjustParallelism(parallelism)
     }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -24,7 +24,7 @@ internal interface SoftLimitedParallelism {
      * @param parallelismDelta a positive or negative value; it is recommended to use +1 and -1.
      * @return the actual adjustment that was made.
      */
-    fun tryAdjustParallelism(parallelismDelta: Byte): Byte
+    fun tryAdjustParallelism(parallelismDelta: Int): Int
 }
 
 /**
@@ -38,7 +38,7 @@ internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int, name: 
     throw UnsupportedOperationException("CoroutineDispatcher.softLimitedParallelism cannot be applied to $this")
 }
 
-internal fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Byte): Byte {
+internal fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Int): Int {
     if (this is SoftLimitedParallelism) {
         return this.tryAdjustParallelism(parallelismDelta)
     }
@@ -79,15 +79,14 @@ internal class SoftLimitedDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte = synchronized(adjustmentLock) {
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int = synchronized(adjustmentLock) {
         // totalParallelism doesn't detect if parallelism was compensated for a specific thread
-        val delta = parallelismDelta.toInt()
-        val targetTotalParallelism = initialParallelism.toLong() + additionalSoftParallelism + delta
+        val targetTotalParallelism = initialParallelism.toLong() + additionalSoftParallelism + parallelismDelta
         if (targetTotalParallelism !in initialParallelism..Int.MAX_VALUE) {
             return 0
         }
-        additionalSoftParallelism += delta
-        availablePermits.addAndGet(delta)
+        additionalSoftParallelism += parallelismDelta
+        availablePermits.addAndGet(parallelismDelta)
 
         // we need to signal scheduler that new worker can be allocated and can take tasks
         // instead of exposing signaling API, let's just dispatch empty task

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -60,7 +60,7 @@ internal class SoftLimitedDispatcher(
     private val hardParallelism: Int? = null
 ) : CoroutineDispatcher(), Delay by (dispatcher as? Delay ?: DefaultDelay), SoftLimitedParallelism {
     private val initialParallelism = parallelism
-    private val additionalSoftParallelism = 0
+    private val additionalSoftParallelism = atomic(0)
     // `parallelism limit - runningWorkers`; may be < 0 if decompensation is expected
     private val availablePermits = atomic(parallelism)
 
@@ -70,7 +70,7 @@ internal class SoftLimitedDispatcher(
 
     // totalParallelism doesn't detect if parallelism was compensated for a specific thread
     private val totalParallelism
-        get() = initialParallelism + additionalSoftParallelism
+        get() = initialParallelism + additionalSoftParallelism.value
 
     override fun limitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher {
         return super.limitedParallelism(parallelism, name)
@@ -82,21 +82,14 @@ internal class SoftLimitedDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int = availablePermits.loop { permits ->
         if (totalParallelism + parallelismDelta !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
-            return 0
+            return 0 // in case parallelism was adjusted by another thread
         }
-        synchronized(workerAllocationLock) {
-            if (totalParallelism + parallelismDelta !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
-                return 0 // in case parallelism was adjusted by another thread
-            }
-            val permits = availablePermits.value
-            val success = availablePermits.compareAndSet(permits, permits + parallelismDelta)
-            if (success) {
-                return parallelismDelta
-            } else {
-                return 0
-            }
+        val success = availablePermits.compareAndSet(permits, permits + parallelismDelta)
+        if (success) {
+            additionalSoftParallelism.addAndGet(parallelismDelta)
+            return parallelismDelta
         }
     }
 

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -69,10 +69,6 @@ internal class SoftLimitedDispatcher(
     private val workerAllocationLock = SynchronizedObject()
     private val adjustmentLock = SynchronizedObject()
 
-    // totalParallelism doesn't detect if parallelism was compensated for a specific thread
-    private val totalParallelism
-        inline get() = initialParallelism + additionalSoftParallelism
-
     override fun limitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher {
         return super.limitedParallelism(parallelism, name)
     }
@@ -84,8 +80,10 @@ internal class SoftLimitedDispatcher(
     }
 
     override fun tryAdjustParallelism(parallelismDelta: Byte): Byte = synchronized(adjustmentLock) {
+        // totalParallelism doesn't detect if parallelism was compensated for a specific thread
         val delta = parallelismDelta.toInt()
-        if (totalParallelism.toLong() + delta !in initialParallelism..Int.MAX_VALUE) {
+        val targetTotalParallelism = initialParallelism.toLong() + additionalSoftParallelism + delta
+        if (targetTotalParallelism !in initialParallelism..Int.MAX_VALUE) {
             return 0
         }
         additionalSoftParallelism += delta

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -18,10 +18,11 @@ internal interface SoftLimitedParallelism {
     /**
      * Attempts to adjust the parallelism limit by [parallelismDelta].
      *
-     * [parallelismDelta] may be a positive or negative value; it is recommended to use +1 and -1.
      * It is not guaranteed that the new parallelism limit will be equal to `oldParallelism + parallelismDelta`:
-     * the adjustment may be applied only partially, or not at all. The function returns the actual
-     * adjustment that was made.
+     * the adjustment may be applied only partially, or not at all.
+     *
+     * @param parallelismDelta a positive or negative value; it is recommended to use +1 and -1.
+     * @return the actual adjustment that was made.
      */
     fun tryAdjustParallelism(parallelismDelta: Int): Int
 }
@@ -41,7 +42,7 @@ internal fun CoroutineDispatcher.tryAdjustParallelism(parallelism: Int): Int {
     if (this is SoftLimitedParallelism) {
         return this.tryAdjustParallelism(parallelism)
     }
-    throw UnsupportedOperationException("CoroutineDispatcher.truAdjustParallelism cannot be applied to $this")
+    throw UnsupportedOperationException("CoroutineDispatcher.tryAdjustParallelism cannot be applied to $this")
 }
 
 /**

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -90,7 +90,9 @@ internal class SoftLimitedDispatcher(
 
         // we need to signal scheduler that new worker can be allocated and can take tasks
         // instead of exposing signaling API, let's just dispatch empty task
-        dispatch(EmptyCoroutineContext, { } )
+        repeat(parallelismDelta.coerceIn(0, queue.size)) {
+            dispatch(EmptyCoroutineContext, { } )
+        }
         return parallelismDelta
     }
 

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -24,7 +24,7 @@ internal interface SoftLimitedParallelism {
      * @param parallelismDelta a positive or negative value; it is recommended to use +1 and -1.
      * @return the actual adjustment that was made.
      */
-    fun tryAdjustParallelism(parallelismDelta: Int): Int
+    fun tryAdjustParallelism(parallelismDelta: Byte): Byte
 }
 
 /**
@@ -38,9 +38,9 @@ internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int, name: 
     throw UnsupportedOperationException("CoroutineDispatcher.softLimitedParallelism cannot be applied to $this")
 }
 
-internal fun CoroutineDispatcher.tryAdjustParallelism(parallelism: Int): Int {
+internal fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Byte): Byte {
     if (this is SoftLimitedParallelism) {
-        return this.tryAdjustParallelism(parallelism)
+        return this.tryAdjustParallelism(parallelismDelta)
     }
     throw UnsupportedOperationException("CoroutineDispatcher.tryAdjustParallelism cannot be applied to $this")
 }
@@ -82,14 +82,17 @@ internal class SoftLimitedDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Int): Int = availablePermits.loop { permits ->
-        if (totalParallelism.toLong() + parallelismDelta !in 1..Int.MAX_VALUE) {
-            return 0
-        }
-        val success = availablePermits.compareAndSet(permits, permits + parallelismDelta)
-        if (success) {
-            additionalSoftParallelism.addAndGet(parallelismDelta)
-            return parallelismDelta
+    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
+        val delta = parallelismDelta.toInt()
+        return availablePermits.loop { permits ->
+            if (totalParallelism.toLong() + delta !in 1..Int.MAX_VALUE) {
+                return 0
+            }
+            val success = availablePermits.compareAndSet(permits, permits + delta)
+            if (success) {
+                additionalSoftParallelism.addAndGet(delta)
+                return parallelismDelta
+            }
         }
     }
 

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -60,17 +60,18 @@ internal class SoftLimitedDispatcher(
     private val name: String?
 ) : CoroutineDispatcher(), Delay by (dispatcher as? Delay ?: DefaultDelay), SoftLimitedParallelism {
     private val initialParallelism = parallelism
-    private val additionalSoftParallelism = atomic(0)
+    private var additionalSoftParallelism = 0
     // `parallelism limit - runningWorkers`; may be < 0 if decompensation is expected
     private val availablePermits = atomic(parallelism)
 
     private val queue = LockFreeTaskQueue<Runnable>(singleConsumer = false)
 
     private val workerAllocationLock = SynchronizedObject()
+    private val adjustmentLock = SynchronizedObject()
 
     // totalParallelism doesn't detect if parallelism was compensated for a specific thread
     private val totalParallelism
-        get() = initialParallelism + additionalSoftParallelism.value
+        inline get() = initialParallelism + additionalSoftParallelism
 
     override fun limitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher {
         return super.limitedParallelism(parallelism, name)
@@ -82,18 +83,14 @@ internal class SoftLimitedDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
+    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte = synchronized(adjustmentLock) {
         val delta = parallelismDelta.toInt()
-        return availablePermits.loop { permits ->
-            if (totalParallelism.toLong() + delta !in 1..Int.MAX_VALUE) {
-                return 0
-            }
-            val success = availablePermits.compareAndSet(permits, permits + delta)
-            if (success) {
-                additionalSoftParallelism.addAndGet(delta)
-                return parallelismDelta
-            }
+        if (totalParallelism.toLong() + delta !in initialParallelism..Int.MAX_VALUE) {
+            return 0
         }
+        additionalSoftParallelism += delta
+        availablePermits.addAndGet(delta)
+        return parallelismDelta
     }
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -14,7 +14,16 @@ import kotlin.coroutines.*
  */
 internal interface SoftLimitedParallelism {
     fun softLimitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher
-    fun adjustParallelism(parallelism: Int)
+
+    /**
+     * Makes an attempt to adjust the parallelism limit by [parallelismDelta].
+     *
+     * [parallelismDelta] may be positive or negative value. It is recommended to use +1 and -1.
+     * It is not guaranteed that new parallelism limit will be equal to `oldParallelism + parallelismDelta`:
+     * it is possible that adjustment will be done only partially or ignored at all. The function
+     * returns the true adjustment that was done.
+     */
+    fun tryAdjustParallelism(parallelismDelta: Int): Int
 }
 
 /**
@@ -28,9 +37,9 @@ internal fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int, name: 
     throw UnsupportedOperationException("CoroutineDispatcher.softLimitedParallelism cannot be applied to $this")
 }
 
-internal fun CoroutineDispatcher.adjustParallelism(parallelism: Int) {
+internal fun CoroutineDispatcher.tryAdjustParallelism(parallelism: Int): Int {
     if (this is SoftLimitedParallelism) {
-        return this.adjustParallelism(parallelism)
+        return this.tryAdjustParallelism(parallelism)
     }
     throw UnsupportedOperationException("CoroutineDispatcher.increaseParallelism cannot be applied to $this")
 }
@@ -73,17 +82,21 @@ internal class SoftLimitedDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun adjustParallelism(parallelism: Int) {
-        if (totalParallelism + parallelism !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
-            return
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+        if (totalParallelism + parallelismDelta !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
+            return 0
         }
         synchronized(workerAllocationLock) {
-            if (totalParallelism + parallelism !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
-                return // in case parallelism was adjusted by another thread
+            if (totalParallelism + parallelismDelta !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
+                return 0 // in case parallelism was adjusted by another thread
             }
             val permits = availablePermits.value
-            availablePermits.compareAndSet(permits, permits + parallelism)
-
+            val success = availablePermits.compareAndSet(permits, permits + parallelismDelta)
+            if (success) {
+                return parallelismDelta
+            } else {
+                return 0
+            }
         }
     }
 

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -57,7 +57,6 @@ internal class SoftLimitedDispatcher(
     private val dispatcher: CoroutineDispatcher,
     parallelism: Int,
     private val name: String?,
-    private val hardParallelism: Int? = null
 ) : CoroutineDispatcher(), Delay by (dispatcher as? Delay ?: DefaultDelay), SoftLimitedParallelism {
     private val initialParallelism = parallelism
     private val additionalSoftParallelism = atomic(0)
@@ -83,8 +82,8 @@ internal class SoftLimitedDispatcher(
     }
 
     override fun tryAdjustParallelism(parallelismDelta: Int): Int = availablePermits.loop { permits ->
-        if (totalParallelism + parallelismDelta !in 1..(hardParallelism ?: Int.MAX_VALUE)) {
-            return 0 // in case parallelism was adjusted by another thread
+        if (totalParallelism.toLong() + parallelismDelta !in 1..Int.MAX_VALUE) {
+            return 0
         }
         val success = availablePermits.compareAndSet(permits, permits + parallelismDelta)
         if (success) {

--- a/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
+++ b/kotlinx-coroutines-core/common/src/internal/SoftLimitedDispatcher.kt
@@ -16,12 +16,12 @@ internal interface SoftLimitedParallelism {
     fun softLimitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher
 
     /**
-     * Makes an attempt to adjust the parallelism limit by [parallelismDelta].
+     * Attempts to adjust the parallelism limit by [parallelismDelta].
      *
-     * [parallelismDelta] may be positive or negative value. It is recommended to use +1 and -1.
-     * It is not guaranteed that new parallelism limit will be equal to `oldParallelism + parallelismDelta`:
-     * it is possible that adjustment will be done only partially or ignored at all. The function
-     * returns the true adjustment that was done.
+     * [parallelismDelta] may be a positive or negative value; it is recommended to use +1 and -1.
+     * It is not guaranteed that the new parallelism limit will be equal to `oldParallelism + parallelismDelta`:
+     * the adjustment may be applied only partially, or not at all. The function returns the actual
+     * adjustment that was made.
      */
     fun tryAdjustParallelism(parallelismDelta: Int): Int
 }
@@ -41,7 +41,7 @@ internal fun CoroutineDispatcher.tryAdjustParallelism(parallelism: Int): Int {
     if (this is SoftLimitedParallelism) {
         return this.tryAdjustParallelism(parallelism)
     }
-    throw UnsupportedOperationException("CoroutineDispatcher.increaseParallelism cannot be applied to $this")
+    throw UnsupportedOperationException("CoroutineDispatcher.truAdjustParallelism cannot be applied to $this")
 }
 
 /**

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -76,7 +76,7 @@ public object IntellijCoroutines {
      * @return the actual adjustment that was made, which is not guaranteed to be equal to [parallelismDelta]:
      * the adjustment may be applied only partially, or not at all (in which case `0` is returned).
      */
-    public fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Byte): Byte {
+    public fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Int): Int {
         return tryAdjustParallelismImpl(parallelismDelta)
     }
 

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlin.coroutines.*
 import kotlinx.coroutines.internal.softLimitedParallelism as softLimitedParallelismImpl
-import kotlinx.coroutines.internal.tryAdjustParallelism as adjustParallelismImpl
+import kotlinx.coroutines.internal.tryAdjustParallelism as tryAdjustParallelismImpl
 import kotlinx.coroutines.internal.SoftLimitedDispatcher
 import kotlinx.coroutines.runBlockingWithParallelismCompensation as runBlockingWithParallelismCompensationImpl
 import kotlinx.coroutines.Dispatchers
@@ -72,8 +72,8 @@ public object IntellijCoroutines {
      * [softLimitedParallelism] has returned. Throws [UnsupportedOperationException] if [this] does not support
      * the parallelism adjustment mechanism.
      */
-    public fun CoroutineDispatcher.adjustParallelism(parallelism: Int) {
-        adjustParallelismImpl(parallelism)
+    public fun CoroutineDispatcher.tryAdjustParallelism(parallelism: Int): Int {
+        return tryAdjustParallelismImpl(parallelism)
     }
 
     /**

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlin.coroutines.*
 import kotlinx.coroutines.internal.softLimitedParallelism as softLimitedParallelismImpl
-import kotlinx.coroutines.internal.adjustParallelism as adjustParallelismImpl
+import kotlinx.coroutines.internal.tryAdjustParallelism as adjustParallelismImpl
 import kotlinx.coroutines.internal.SoftLimitedDispatcher
 import kotlinx.coroutines.runBlockingWithParallelismCompensation as runBlockingWithParallelismCompensationImpl
 import kotlinx.coroutines.Dispatchers

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -76,7 +76,7 @@ public object IntellijCoroutines {
      * @return the actual adjustment that was made, which is not guaranteed to be equal to [parallelismDelta]:
      * the adjustment may be applied only partially, or not at all (in which case `0` is returned).
      */
-    public fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Int): Int {
+    public fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Byte): Byte {
         return tryAdjustParallelismImpl(parallelismDelta)
     }
 

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -68,13 +68,14 @@ public object IntellijCoroutines {
      * Adjusts the parallelism of [this] dispatcher by [parallelismDelta].
      *
      * This extension can only be used on instances of [Dispatchers.Default], [Dispatchers.IO] and also on what
-     * [softLimitedParallelism] has returned. Throws [UnsupportedOperationException] if [this] does not support
-     * the parallelism adjustment mechanism.
+     * [softLimitedParallelism] has returned.  The parallelism can not be decreased below the initial value.
+     * The method does the best effort to adjust parallelism, the actual applied value can be less (or 0) than
+     * requested. Throws [UnsupportedOperationException] if [this] does not support the parallelism adjustment
+     * mechanism.
      *
      * @param parallelismDelta a positive or negative adjustment to the parallelism limit;
      *        a negative value reclaims previously granted parallelism.
-     * @return the actual adjustment that was made, which is not guaranteed to be equal to [parallelismDelta]:
-     * the adjustment may be applied only partially, or not at all (in which case `0` is returned).
+     * @return the actual adjustment that was made.
      */
     public fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Int): Int {
         return tryAdjustParallelismImpl(parallelismDelta)

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlin.coroutines.*
 import kotlinx.coroutines.internal.softLimitedParallelism as softLimitedParallelismImpl
+import kotlinx.coroutines.internal.adjustParallelism as adjustParallelismImpl
 import kotlinx.coroutines.internal.SoftLimitedDispatcher
 import kotlinx.coroutines.runBlockingWithParallelismCompensation as runBlockingWithParallelismCompensationImpl
 import kotlinx.coroutines.Dispatchers
@@ -62,6 +63,18 @@ public object IntellijCoroutines {
     @Deprecated("use named version", level = DeprecationLevel.HIDDEN)
     public fun CoroutineDispatcher.softLimitedParallelism(parallelism: Int): CoroutineDispatcher =
         softLimitedParallelismImpl(parallelism, null)
+
+    /**
+     * Adjusts the parallelism of [this] dispatcher by [parallelism], which may be negative to reclaim
+     * previously granted parallelism.
+     *
+     * This extension can only be used on instances of [Dispatchers.Default], [Dispatchers.IO] and also on what
+     * [softLimitedParallelism] has returned. Throws [UnsupportedOperationException] if [this] does not support
+     * the parallelism adjustment mechanism.
+     */
+    public fun CoroutineDispatcher.adjustParallelism(parallelism: Int) {
+        adjustParallelismImpl(parallelism)
+    }
 
     /**
      * Executes [action] and **advises** to compensate parallelism if [action] does not finish within [timeout].

--- a/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
+++ b/kotlinx-coroutines-core/jvm/src/internal/intellij/intellij.kt
@@ -65,15 +65,19 @@ public object IntellijCoroutines {
         softLimitedParallelismImpl(parallelism, null)
 
     /**
-     * Adjusts the parallelism of [this] dispatcher by [parallelism], which may be negative to reclaim
-     * previously granted parallelism.
+     * Adjusts the parallelism of [this] dispatcher by [parallelismDelta].
      *
      * This extension can only be used on instances of [Dispatchers.Default], [Dispatchers.IO] and also on what
      * [softLimitedParallelism] has returned. Throws [UnsupportedOperationException] if [this] does not support
      * the parallelism adjustment mechanism.
+     *
+     * @param parallelismDelta a positive or negative adjustment to the parallelism limit;
+     *        a negative value reclaims previously granted parallelism.
+     * @return the actual adjustment that was made, which is not guaranteed to be equal to [parallelismDelta]:
+     * the adjustment may be applied only partially, or not at all (in which case `0` is returned).
      */
-    public fun CoroutineDispatcher.tryAdjustParallelism(parallelism: Int): Int {
-        return tryAdjustParallelismImpl(parallelism)
+    public fun CoroutineDispatcher.tryAdjustParallelism(parallelismDelta: Int): Int {
+        return tryAdjustParallelismImpl(parallelismDelta)
     }
 
     /**

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -648,11 +648,11 @@ internal class CoroutineScheduler(
      * The amount of compensated threads cannot exceed [MAX_OUTSTANDING_CPU_COMPENSATIONS].
      *
      * The CPU compensation mechanism is part of the IntelliJ patch and has not been tested for
-     * all corner cases, such as [corePoolSize] == [MAX_SUPPORTED_POOL_SIZE], where an integer overflow
+     * all corner cases, such as [MAX_SUPPORTED_POOL_SIZE] parallel blocking task running, where an integer overflow
      * is possible.
      *
      * @return `true` if the parallelism was increased, `false` if the scheduler is already terminated or
-     * [MAX_OUTSTANDING_CPU_COMPENSATIONS] has already been reached.
+     * [MAX_OUTSTANDING_CPU_COMPENSATIONS] or [maxPoolSize] has already been reached.
      */
     fun tryIncreaseCpuParallelism(): Boolean = synchronized(compensationLock) {
         if (isTerminated) return false

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -359,6 +359,14 @@ internal class CoroutineScheduler(
         if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding - 1)) return true
     }
 
+    private fun tryDecrementBlockingTaskIfNoCpuPermitAvailable(): Boolean {
+        val state = controlState.value
+        if (availableCpuPermits(state) > 0) return false
+        assert{ blockingTasks(state) > 0 }
+        val updatedState = state - (1L shl BLOCKING_SHIFT)
+        return controlState.compareAndSet(state, updatedState)
+    }
+
     // This is used a "stop signal" for close and shutdown functions
     private val _isTerminated = atomic(false)
     val isTerminated: Boolean get() = _isTerminated.value
@@ -692,11 +700,17 @@ internal class CoroutineScheduler(
         // Blocking tasks cannot go below 0: CPU parallelism can decrease only when there
         // is an outstanding CPU compensation, so for every blocking task decrement there is
         // a matching incrementBlockingTasks() call done in [tryIncreaseCpuParallelism].
-
-        if (!tryAcquireCpuPermitAndDecrementBlockingTasks()) {
-            decrementBlockingTasks()
-            cpuDecompensationRequests.incrementAndGet()
+        while(true) {
+            if (tryAcquireCpuPermitAndDecrementBlockingTasks()) {
+                break
+            } else {
+                if (tryDecrementBlockingTaskIfNoCpuPermitAvailable()) {
+                    cpuDecompensationRequests.incrementAndGet()
+                    break
+                }
+            }
         }
+
 
         return true
     }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -333,7 +333,8 @@ internal class CoroutineScheduler(
     private inline fun tryAcquireCpuPermitAndDecrementBlockingTasks(): Boolean = controlState.loop { state ->
         val available = availableCpuPermits(state)
         if (available == 0) return false
-        if (blockingTasks(state) == 0) return false
+        assert{ blockingTasks(state) > 0 } // Catch issues easier during tests
+        if (blockingTasks(state) == 0) return false // But avoid invalid states during runtime
         val update = state - (1L shl CPU_PERMITS_SHIFT) - (1L shl BLOCKING_SHIFT)
         if (controlState.compareAndSet(state, update)) return true
     }
@@ -353,7 +354,8 @@ internal class CoroutineScheduler(
     private fun tryDecrementBlockingTaskIfNoCpuPermitAvailable(): Boolean {
         val state = controlState.value
         if (availableCpuPermits(state) > 0) return false
-        if (blockingTasks(state) == 0) return false
+        assert{ blockingTasks(state) > 0 } // Catch issues easier during tests
+        if (blockingTasks(state) == 0) return false // But avoid invalid states during runtime
         val updatedState = state - (1L shl BLOCKING_SHIFT)
         return controlState.compareAndSet(state, updatedState)
     }
@@ -847,7 +849,6 @@ internal class CoroutineScheduler(
             if (decompensationRequests == 0) {
                 return false
             }
-
             assert { state == WorkerState.CPU_ACQUIRED }
             while (decompensationRequests > 0) {
                 if (!cpuDecompensationRequests.compareAndSet(decompensationRequests, decompensationRequests - 1)) {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -383,6 +383,7 @@ internal class CoroutineScheduler(
 
         internal const val MIN_SUPPORTED_POOL_SIZE = 1 // we support 1 for test purposes, but it is not usually used
         internal const val MAX_SUPPORTED_POOL_SIZE = (1 shl BLOCKING_SHIFT) - 2
+
         // Masks of parkedWorkersStack
         private const val PARKED_INDEX_MASK = CREATED_MASK
         private const val PARKED_VERSION_MASK = CREATED_MASK.inv()
@@ -716,7 +717,6 @@ internal class CoroutineScheduler(
                 }
             }
         }
-
 
         return true
     }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -297,11 +297,9 @@ internal class CoroutineScheduler(
     private val cpuDecompensationRequests = atomic(0)
 
     /**
-     * Number of CPU permits added by genuine (not cancelled-out) [increaseCpuParallelism] calls that have not
-     * yet been reclaimed by a matching [decreaseCpuParallelism] call. Acts as a floor: [decreaseCpuParallelism]
-     * may only register a real give-back request if it can claim one unit of this counter. This guarantees
-     * [availableCpuPermits] can never be decompensated below [corePoolSize] by a [decreaseCpuParallelism] call
-     * that has no matching prior [increaseCpuParallelism].
+     * Number of CPU permits added by [tryIncrementCpuParallelism] calls that have not
+     * yet been reclaimed by a matching [tryDecreaseCpuParallelism] call. Acts as a safe-mechanism that guarantees
+     * that [outstandingCpuCompensations] is in the 0..[MAX_OUTSTANDING_CPU_COMPENSATIONS] range.
      */
     private val outstandingCpuCompensations = atomic(0)
 
@@ -339,6 +337,11 @@ internal class CoroutineScheduler(
         return cpuDecompensationRequests.compareAndSet(requests, requests - 1)
     }
 
+    private fun tryIncrementOutstandingCpuCompensations(): Boolean = outstandingCpuCompensations.loop { outstanding ->
+        if (outstanding > MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
+        if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding + 1)) return true
+    }
+
     private inline fun tryDecrementOutstandingCpuCompensations(): Boolean = outstandingCpuCompensations.loop { outstanding ->
         if (outstanding == 0) return false
         if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding - 1)) return true
@@ -367,7 +370,7 @@ internal class CoroutineScheduler(
 
         internal const val MIN_SUPPORTED_POOL_SIZE = 1 // we support 1 for test purposes, but it is not usually used
         internal const val MAX_SUPPORTED_POOL_SIZE = (1 shl BLOCKING_SHIFT) - 2
-
+        internal const val MAX_OUTSTANDING_CPU_COMPENSATIONS = 1024
         // Masks of parkedWorkersStack
         private const val PARKED_INDEX_MASK = CREATED_MASK
         private const val PARKED_VERSION_MASK = CREATED_MASK.inv()
@@ -384,7 +387,7 @@ internal class CoroutineScheduler(
         if (!_isTerminated.compareAndSet(false, true)) return
 
         while (outstandingCpuCompensations.value > 0) {
-            decreaseCpuParallelism()
+            tryDecreaseCpuParallelism()
         }
 
         // make sure we are not waiting for the current thread
@@ -626,34 +629,53 @@ internal class CoroutineScheduler(
     /**
      * Increase the amount of allowed CPU threads.
      *
-     * Part of IntelliJ-patch.
+     * The amount of compensated threads can not be exceed [MAX_OUTSTANDING_CPU_COMPENSATIONS]
+     *
+     * Mechanism of cpu compensation is a part of IntelliJ-patch, and has not been tested for
+     * all corner cases such as [corePoolSize] = [MAX_SUPPORTED_POOL_SIZE], where integer overflow
+     * is possible
      */
-    fun increaseCpuParallelism() {
-        if (isTerminated) return
+    fun tryIncrementCpuParallelism(): Boolean {
+        if (isTerminated) return false
         if (tryDecrementDecompensationRequests()) {
             // instead of increasing the parallelism limit, we removed a request to decrease it
         } else {
-            outstandingCpuCompensations.incrementAndGet()
+            if (!tryIncrementOutstandingCpuCompensations()) {
+                return false
+            }
             releaseCpuPermit()
+
+            // CPU workers are counted as `number of workers - number of blocking tasks`
+            // New cpu worker can be allocated only if there is less cpu workers than [corePoolSize]
+            // [corePoolSize] is a constant value, and change it may lead to unexpected bugs
+            // Fakely increment number of blocking tasks, to artificially decrease the number
+            // of cpu workers.
             incrementBlockingTasks() // Fake blocking tasks to hack cpuWorkers
         }
         signalCpuWork()
+        return true
     }
 
     /**
      * Decrease the amount of allowed CPU threads.
      * Can not decrease the amount below than initial [corePoolSize], in this case
-     * the function does nothing.
+     * the function does nothing and returns `false`.
      *
      * This function is a part of IntelliJ-patch
      */
-    fun decreaseCpuParallelism() {
-        if (tryDecrementOutstandingCpuCompensations()) {
-            if (!tryAcquireCpuPermit()) {
-                cpuDecompensationRequests.incrementAndGet()
-            }
-            decrementBlockingTasks()
+    fun tryDecreaseCpuParallelism(): Boolean {
+        if (!tryDecrementOutstandingCpuCompensations()) return false
+        if (!tryAcquireCpuPermit()) {
+            cpuDecompensationRequests.incrementAndGet()
         }
+        // Cpu permit is acquired, which decreases available cpu permits
+        // Artificially decrease the number of blocking taks, to correctly calculate
+        // number of cpu workers. See [increaseCpuParallelism] for more details.
+        // Blocking tasks can not go below 0, cpu parallelism can decrease only when there
+        // is an outstanding cpu compensation. So for every blocking task decrement there is
+        // a matching incrementBlockingTasks done in [increasingCpuParallelism]
+        decrementBlockingTasks()
+        return true
     }
 
     /** see [Worker.runTaskSafely] */
@@ -1144,7 +1166,7 @@ internal class CoroutineScheduler(
                 // increasing the number of blocking tasks and the available cpu permits. The increase in the number
                 // of blocking tasks will make the scheduler treat the current worker as a non-CPU one.
                 incrementBlockingTasks()
-                increaseCpuParallelism()
+                tryIncrementCpuParallelism()
             }
             val taskParallelismCompensation = (currentTask as? TaskImpl)?.block as? ParallelismCompensation
             taskParallelismCompensation?.increaseParallelismAndLimit()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -656,6 +656,10 @@ internal class CoroutineScheduler(
     fun tryIncreaseCpuParallelism(): Boolean = synchronized(compensationLock) {
         if (isTerminated) return false
 
+        // Disable adjustment in extreme cases where corePoolSize or maxPoolSize are large enough to risk overflow
+        if (corePoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE) return false
+        if (maxPoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE) return false
+
         if (outstandingCpuCompensations >= MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
         outstandingCpuCompensations++
 

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -623,6 +623,11 @@ internal class CoroutineScheduler(
             "}]"
     }
 
+    /**
+     * Increase the amount of allowed CPU threads.
+     *
+     * Part of IntelliJ-patch.
+     */
     fun increaseCpuParallelism() {
         if (isTerminated) return
         if (tryDecrementDecompensationRequests()) {
@@ -636,20 +641,11 @@ internal class CoroutineScheduler(
     }
 
     /**
-     * Requests that one previously-added CPU permit (from a matching [increaseCpuParallelism] call) be given
-     * back to the pool the next time some CPU-permit-holding worker reaches a safe point
-     * (see [Worker.tryDecompensateCpu]).
+     * Decrease the amount of allowed CPU threads.
+     * Can not decrease the amount below than initial [corePoolSize], in this case
+     * the function does nothing.
      *
-     * Floor invariant: this only has an effect if [outstandingCpuCompensations] has a spare unit, i.e. there was
-     * a genuine, not-yet-reclaimed prior [increaseCpuParallelism] call. Without this check, an unpaired call
-     * here could eventually drain [availableCpuPermits] below [corePoolSize], permanently starving the pool.
-     * If there is no such unit, this call is a safe no-op.
-     *
-     * Known, accepted conservatism: if [increaseCpuParallelism]'s cancel-a-pending-decrease branch fires for a
-     * decrease request *after* this method already consumed a unit of [outstandingCpuCompensations] for that
-     * same request, [outstandingCpuCompensations] can end up slightly under-counting real headroom (a future
-     * legitimate decrease may be refused even though it would have been safe) — this is intentionally accepted
-     * as a safety-over-liveness tradeoff, not something to engineer around.
+     * This function is a part of IntelliJ-patch
      */
     fun decreaseCpuParallelism() {
         if (tryDecrementOutstandingCpuCompensations()) {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -657,10 +657,13 @@ internal class CoroutineScheduler(
         if (isTerminated) return false
 
         // Disable adjustment in extreme cases where corePoolSize or maxPoolSize are large enough to risk overflow
-        if (corePoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE) return false
-        if (maxPoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE) return false
+        if (corePoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE ||
+            maxPoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE ||
+            outstandingCpuCompensations >= MAX_OUTSTANDING_CPU_COMPENSATIONS ||
+            outstandingCpuCompensations >= maxPoolSize - corePoolSize) {
+            return false
+        }
 
-        if (outstandingCpuCompensations >= MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
         outstandingCpuCompensations++
 
         if (tryDecrementDecompensationRequests()) {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -382,7 +382,6 @@ internal class CoroutineScheduler(
 
         internal const val MIN_SUPPORTED_POOL_SIZE = 1 // we support 1 for test purposes, but it is not usually used
         internal const val MAX_SUPPORTED_POOL_SIZE = (1 shl BLOCKING_SHIFT) - 2
-        internal const val MAX_OUTSTANDING_CPU_COMPENSATIONS = 1024
         // Masks of parkedWorkersStack
         private const val PARKED_INDEX_MASK = CREATED_MASK
         private const val PARKED_VERSION_MASK = CREATED_MASK.inv()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -332,7 +332,7 @@ internal class CoroutineScheduler(
     private inline fun tryAcquireCpuPermitAndDecrementBlockingTasks(): Boolean = controlState.loop { state ->
         val available = availableCpuPermits(state)
         if (available == 0) return false
-        assert { blockingTasks(state) > 0 }
+        if (blockingTasks(state) == 0) return false
         val update = state - (1L shl CPU_PERMITS_SHIFT) - (1L shl BLOCKING_SHIFT)
         if (controlState.compareAndSet(state, update)) return true
     }
@@ -350,7 +350,7 @@ internal class CoroutineScheduler(
     }
 
     private fun tryIncrementOutstandingCpuCompensations(): Boolean = outstandingCpuCompensations.loop { outstanding ->
-        if (outstanding > MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
+        if (outstanding >= MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
         if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding + 1)) return true
     }
 
@@ -362,7 +362,7 @@ internal class CoroutineScheduler(
     private fun tryDecrementBlockingTaskIfNoCpuPermitAvailable(): Boolean {
         val state = controlState.value
         if (availableCpuPermits(state) > 0) return false
-        assert{ blockingTasks(state) > 0 }
+        if (blockingTasks(state) == 0) return false
         val updatedState = state - (1L shl BLOCKING_SHIFT)
         return controlState.compareAndSet(state, updatedState)
     }
@@ -660,6 +660,15 @@ internal class CoroutineScheduler(
      */
     fun tryIncreaseCpuParallelism(): Boolean {
         if (isTerminated) return false
+
+        // There can be a race condition if [tryDecreaseCpuParallelism] has decreased
+        // outstandingCpuCompensation but hasn't effectively applied the decrease yet.
+        // This may lead to a situation where, for a short moment, there are more additional
+        // CPU workers than [MAX_OUTSTANDING_CPU_COMPENSATION] allows.
+        // In the very unlikely worst case, blocking tasks (or CPU permits) in controlState
+        // could overflow, but [MAX_OUTSTANDING_CPU_COMPENSATION] is deliberately chosen to
+        // be small, and there would need to be ~1M races happening simultaneously for this
+        // to happen.
         if (!tryIncrementOutstandingCpuCompensations()) {
             return false
         }
@@ -701,6 +710,10 @@ internal class CoroutineScheduler(
         // is an outstanding CPU compensation, so for every blocking task decrement there is
         // a matching incrementBlockingTasks() call done in [tryIncreaseCpuParallelism].
         while(true) {
+            // The loop to ensure that:
+            // a) blocking tasks are decremented either with acquiring cpu permit or when there is no cpu permits
+            // b) blocking tasks can not go below 0: shielding the race condition when [tryIncreaseCpuParallelism] has
+            // increased outstandingCpuCompensation but hasn't effectively increased the parallism yet
             if (tryAcquireCpuPermitAndDecrementBlockingTasks()) {
                 break
             } else {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -301,7 +301,8 @@ internal class CoroutineScheduler(
      * yet been reclaimed by a matching [tryDecreaseCpuParallelism] call. Acts as a safety mechanism that
      * guarantees this counter stays within the 0..[MAX_OUTSTANDING_CPU_COMPENSATIONS] range.
      */
-    private val outstandingCpuCompensations = atomic(0)
+    private var outstandingCpuCompensations = 0
+    private val compensationLock = SynchronizedObject()
 
     private val createdWorkers: Int inline get() = (controlState.value and CREATED_MASK).toInt()
     private val availableCpuPermits: Int inline get() = availableCpuPermits(controlState.value)
@@ -347,16 +348,6 @@ internal class CoroutineScheduler(
         if (requests == 0) return false
         assert { requests > 0 }
         return cpuDecompensationRequests.compareAndSet(requests, requests - 1)
-    }
-
-    private fun tryIncrementOutstandingCpuCompensations(): Boolean = outstandingCpuCompensations.loop { outstanding ->
-        if (outstanding >= MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
-        if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding + 1)) return true
-    }
-
-    private inline fun tryDecrementOutstandingCpuCompensations(): Boolean = outstandingCpuCompensations.loop { outstanding ->
-        if (outstanding == 0) return false
-        if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding - 1)) return true
     }
 
     private fun tryDecrementBlockingTaskIfNoCpuPermitAvailable(): Boolean {
@@ -405,9 +396,11 @@ internal class CoroutineScheduler(
         // atomically set termination flag which is checked when workers are added or removed
         if (!_isTerminated.compareAndSet(false, true)) return
 
-        while (outstandingCpuCompensations.value > 0) {
-            val decreased = tryDecreaseCpuParallelism()
-            assert(decreased)
+        synchronized(compensationLock) {
+            while (outstandingCpuCompensations > 0) {
+                val decreased = tryDecreaseCpuParallelism()
+                assert(decreased)
+            }
         }
 
         // make sure we are not waiting for the current thread
@@ -658,20 +651,11 @@ internal class CoroutineScheduler(
      * @return `true` if the parallelism was increased, `false` if the scheduler is already terminated or
      * [MAX_OUTSTANDING_CPU_COMPENSATIONS] has already been reached.
      */
-    fun tryIncreaseCpuParallelism(): Boolean {
+    fun tryIncreaseCpuParallelism(): Boolean = synchronized(compensationLock) {
         if (isTerminated) return false
 
-        // There can be a race condition if [tryDecreaseCpuParallelism] has decreased
-        // outstandingCpuCompensation but hasn't effectively applied the decrease yet.
-        // This may lead to a situation where, for a short moment, there are more additional
-        // CPU workers than [MAX_OUTSTANDING_CPU_COMPENSATION] allows.
-        // In the very unlikely worst case, blocking tasks (or CPU permits) in controlState
-        // could overflow, but [MAX_OUTSTANDING_CPU_COMPENSATION] is deliberately chosen to
-        // be small, and there would need to be ~1M races happening simultaneously for this
-        // to happen.
-        if (!tryIncrementOutstandingCpuCompensations()) {
-            return false
-        }
+        if (outstandingCpuCompensations >= MAX_OUTSTANDING_CPU_COMPENSATIONS) return false
+        outstandingCpuCompensations++
 
         if (tryDecrementDecompensationRequests()) {
             // instead of increasing the parallelism limit, we removed a request to decrease it
@@ -700,8 +684,9 @@ internal class CoroutineScheduler(
      * @return `true` if the parallelism was decreased, `false` if there is no outstanding
      * [tryIncreaseCpuParallelism] call left to reclaim.
      */
-    fun tryDecreaseCpuParallelism(): Boolean {
-        if (!tryDecrementOutstandingCpuCompensations()) return false
+    fun tryDecreaseCpuParallelism(): Boolean = synchronized(compensationLock) {
+        if (outstandingCpuCompensations <= 0) return false
+        outstandingCpuCompensations--
 
         // A CPU permit is acquired, which decreases the available CPU permits.
         // Artificially decrease the number of blocking tasks, to correctly calculate
@@ -712,8 +697,7 @@ internal class CoroutineScheduler(
         while(true) {
             // The loop to ensure that:
             // a) blocking tasks are decremented either with acquiring cpu permit or when there is no cpu permits
-            // b) blocking tasks can not go below 0: shielding the race condition when [tryIncreaseCpuParallelism] has
-            // increased outstandingCpuCompensation but hasn't effectively increased the parallism yet
+            // b) blocking tasks can not go below 0
             if (tryAcquireCpuPermitAndDecrementBlockingTasks()) {
                 break
             } else {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -640,13 +640,16 @@ internal class CoroutineScheduler(
     }
 
     /**
-     * Increases the amount of allowed CPU threads.
+     * Increases the amount of allowed CPU threads by one.
      *
      * The amount of compensated threads cannot exceed [MAX_OUTSTANDING_CPU_COMPENSATIONS].
      *
      * The CPU compensation mechanism is part of the IntelliJ patch and has not been tested for
      * all corner cases, such as [corePoolSize] == [MAX_SUPPORTED_POOL_SIZE], where an integer overflow
      * is possible.
+     *
+     * @return `true` if the parallelism was increased, `false` if the scheduler is already terminated or
+     * [MAX_OUTSTANDING_CPU_COMPENSATIONS] has already been reached.
      */
     fun tryIncreaseCpuParallelism(): Boolean {
         if (isTerminated) return false
@@ -670,21 +673,26 @@ internal class CoroutineScheduler(
     }
 
     /**
-     * Decreases the amount of allowed CPU threads.
+     * Decreases the amount of allowed CPU threads by one, reclaiming a previous
+     * [tryIncreaseCpuParallelism] call.
+     *
      * Cannot decrease the amount below the initial [corePoolSize]; in this case
      * the function does nothing and returns `false`.
      *
      * This function is part of the IntelliJ patch.
+     *
+     * @return `true` if the parallelism was decreased, `false` if there is no outstanding
+     * [tryIncreaseCpuParallelism] call left to reclaim.
      */
     fun tryDecreaseCpuParallelism(): Boolean {
         if (!tryDecrementOutstandingCpuCompensations()) return false
 
         // A CPU permit is acquired, which decreases the available CPU permits.
         // Artificially decrease the number of blocking tasks, to correctly calculate
-        // the number of CPU workers. See [tryIncrementCpuParallelism] for more details.
+        // the number of CPU workers. See [tryIncreaseCpuParallelism] for more details.
         // Blocking tasks cannot go below 0: CPU parallelism can decrease only when there
         // is an outstanding CPU compensation, so for every blocking task decrement there is
-        // a matching incrementBlockingTasks() call done in [tryIncrementCpuParallelism].
+        // a matching incrementBlockingTasks() call done in [tryIncreaseCpuParallelism].
 
         if (!tryAcquireCpuPermitAndDecrementBlockingTasks()) {
             decrementBlockingTasks()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -329,6 +329,9 @@ internal class CoroutineScheduler(
     }
 
     private inline fun releaseCpuPermit() = controlState.addAndGet(1L shl CPU_PERMITS_SHIFT)
+    private inline fun releaseCpuPermitAndIncrementBlockingWorkers() = controlState.addAndGet(
+        (1L shl CPU_PERMITS_SHIFT) or (1L shl BLOCKING_SHIFT)
+    )
 
     private fun tryDecrementDecompensationRequests(): Boolean {
         val requests = cpuDecompensationRequests.value
@@ -639,18 +642,18 @@ internal class CoroutineScheduler(
         if (isTerminated) return false
         if (tryDecrementDecompensationRequests()) {
             // instead of increasing the parallelism limit, we removed a request to decrease it
+            incrementBlockingTasks()
         } else {
             if (!tryIncrementOutstandingCpuCompensations()) {
                 return false
             }
-            releaseCpuPermit()
 
             // CPU workers are counted as `number of workers - number of blocking tasks`.
             // A new CPU worker can be allocated only if there are fewer CPU workers than [corePoolSize].
             // [corePoolSize] is a constant value, and changing it may lead to unexpected bugs.
             // Artificially increment the number of blocking tasks to decrease the number
             // of CPU workers.
-            incrementBlockingTasks() // Fake blocking tasks to hack cpuWorkers
+            releaseCpuPermitAndIncrementBlockingWorkers()
         }
         signalCpuWork()
         return true
@@ -1165,11 +1168,11 @@ internal class CoroutineScheduler(
                 // hard-to-notice concurrency issues. Instead, let's increase the core pool size effectively by
                 // increasing the number of blocking tasks and the available cpu permits. The increase in the number
                 // of blocking tasks will make the scheduler treat the current worker as a non-CPU one.
-                incrementBlockingTasks()
                 if (tryDecrementDecompensationRequests()) {
                     // instead of increasing the parallelism limit, we removed a request to decrease it
+                    incrementBlockingTasks()
                 } else {
-                    releaseCpuPermit()
+                    releaseCpuPermitAndIncrementBlockingWorkers()
                 }
                 signalCpuWork()
             }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -297,7 +297,7 @@ internal class CoroutineScheduler(
     private val cpuDecompensationRequests = atomic(0)
 
     /**
-     * Number of CPU permits added by [tryIncrementCpuParallelism] calls that have not
+     * Number of CPU permits added by [tryIncreaseCpuParallelism] calls that have not
      * yet been reclaimed by a matching [tryDecreaseCpuParallelism] call. Acts as a safety mechanism that
      * guarantees this counter stays within the 0..[MAX_OUTSTANDING_CPU_COMPENSATIONS] range.
      */
@@ -648,7 +648,7 @@ internal class CoroutineScheduler(
      * all corner cases, such as [corePoolSize] == [MAX_SUPPORTED_POOL_SIZE], where an integer overflow
      * is possible.
      */
-    fun tryIncrementCpuParallelism(): Boolean {
+    fun tryIncreaseCpuParallelism(): Boolean {
         if (isTerminated) return false
         if (!tryIncrementOutstandingCpuCompensations()) {
             return false

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -318,13 +318,22 @@ internal class CoroutineScheduler(
     private inline fun incrementBlockingTasks() = controlState.addAndGet(1L shl BLOCKING_SHIFT)
 
     private inline fun decrementBlockingTasks() {
-        controlState.addAndGet(-(1L shl BLOCKING_SHIFT))
+        val oldState = controlState.getAndAdd(-(1L shl BLOCKING_SHIFT))
+        assert{ blockingTasks(oldState) > 0 }
     }
 
     private inline fun tryAcquireCpuPermit(): Boolean = controlState.loop { state ->
         val available = availableCpuPermits(state)
         if (available == 0) return false
         val update = state - (1L shl CPU_PERMITS_SHIFT)
+        if (controlState.compareAndSet(state, update)) return true
+    }
+
+    private inline fun tryAcquireCpuPermitAndDecrementBlockingTasks(): Boolean = controlState.loop { state ->
+        val available = availableCpuPermits(state)
+        if (available == 0) return false
+        assert { blockingTasks(state) > 0 }
+        val update = state - (1L shl CPU_PERMITS_SHIFT) - (1L shl BLOCKING_SHIFT)
         if (controlState.compareAndSet(state, update)) return true
     }
 
@@ -668,16 +677,18 @@ internal class CoroutineScheduler(
      */
     fun tryDecreaseCpuParallelism(): Boolean {
         if (!tryDecrementOutstandingCpuCompensations()) return false
-        if (!tryAcquireCpuPermit()) {
-            cpuDecompensationRequests.incrementAndGet()
-        }
+
         // A CPU permit is acquired, which decreases the available CPU permits.
         // Artificially decrease the number of blocking tasks, to correctly calculate
         // the number of CPU workers. See [tryIncrementCpuParallelism] for more details.
         // Blocking tasks cannot go below 0: CPU parallelism can decrease only when there
         // is an outstanding CPU compensation, so for every blocking task decrement there is
         // a matching incrementBlockingTasks() call done in [tryIncrementCpuParallelism].
-        decrementBlockingTasks()
+
+        if (!tryAcquireCpuPermitAndDecrementBlockingTasks()) {
+            decrementBlockingTasks()
+        }
+
         return true
     }
 

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -1189,11 +1189,11 @@ internal class CoroutineScheduler(
                 // hard-to-notice concurrency issues. Instead, let's increase the core pool size effectively by
                 // increasing the number of blocking tasks and the available cpu permits. The increase in the number
                 // of blocking tasks will make the scheduler treat the current worker as a non-CPU one.
+                incrementBlockingTasks()
                 if (tryDecrementDecompensationRequests()) {
                     // instead of increasing the parallelism limit, we removed a request to decrease it
-                    incrementBlockingTasks()
                 } else {
-                    releaseCpuPermitAndIncrementBlockingWorkers()
+                    releaseCpuPermit()
                 }
                 signalCpuWork()
             }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -1166,7 +1166,12 @@ internal class CoroutineScheduler(
                 // increasing the number of blocking tasks and the available cpu permits. The increase in the number
                 // of blocking tasks will make the scheduler treat the current worker as a non-CPU one.
                 incrementBlockingTasks()
-                tryIncrementCpuParallelism()
+                if (tryDecrementDecompensationRequests()) {
+                    // instead of increasing the parallelism limit, we removed a request to decrease it
+                } else {
+                    releaseCpuPermit()
+                }
+                signalCpuWork()
             }
             val taskParallelismCompensation = (currentTask as? TaskImpl)?.block as? ParallelismCompensation
             taskParallelismCompensation?.increaseParallelismAndLimit()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -399,7 +399,8 @@ internal class CoroutineScheduler(
         if (!_isTerminated.compareAndSet(false, true)) return
 
         while (outstandingCpuCompensations.value > 0) {
-            tryDecreaseCpuParallelism()
+            val decreased = tryDecreaseCpuParallelism()
+            assert(decreased)
         }
 
         // make sure we are not waiting for the current thread
@@ -649,14 +650,14 @@ internal class CoroutineScheduler(
      */
     fun tryIncrementCpuParallelism(): Boolean {
         if (isTerminated) return false
+        if (!tryIncrementOutstandingCpuCompensations()) {
+            return false
+        }
+
         if (tryDecrementDecompensationRequests()) {
             // instead of increasing the parallelism limit, we removed a request to decrease it
             incrementBlockingTasks()
         } else {
-            if (!tryIncrementOutstandingCpuCompensations()) {
-                return false
-            }
-
             // CPU workers are counted as `number of workers - number of blocking tasks`.
             // A new CPU worker can be allocated only if there are fewer CPU workers than [corePoolSize].
             // [corePoolSize] is a constant value, and changing it may lead to unexpected bugs.
@@ -687,6 +688,7 @@ internal class CoroutineScheduler(
 
         if (!tryAcquireCpuPermitAndDecrementBlockingTasks()) {
             decrementBlockingTasks()
+            cpuDecompensationRequests.incrementAndGet()
         }
 
         return true

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -630,6 +630,7 @@ internal class CoroutineScheduler(
         } else {
             outstandingCpuCompensations.incrementAndGet()
             releaseCpuPermit()
+            incrementBlockingTasks() // Fake blocking tasks to hack cpuWorkers
         }
         signalCpuWork()
     }
@@ -655,6 +656,7 @@ internal class CoroutineScheduler(
             if (!tryAcquireCpuPermit()) {
                 cpuDecompensationRequests.incrementAndGet()
             }
+            decrementBlockingTasks()
         }
     }
 

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -296,6 +296,15 @@ internal class CoroutineScheduler(
      */
     private val cpuDecompensationRequests = atomic(0)
 
+    /**
+     * Number of CPU permits added by genuine (not cancelled-out) [increaseCpuParallelism] calls that have not
+     * yet been reclaimed by a matching [decreaseCpuParallelism] call. Acts as a floor: [decreaseCpuParallelism]
+     * may only register a real give-back request if it can claim one unit of this counter. This guarantees
+     * [availableCpuPermits] can never be decompensated below [corePoolSize] by a [decreaseCpuParallelism] call
+     * that has no matching prior [increaseCpuParallelism].
+     */
+    private val outstandingCpuCompensations = atomic(0)
+
     private val createdWorkers: Int inline get() = (controlState.value and CREATED_MASK).toInt()
     private val availableCpuPermits: Int inline get() = availableCpuPermits(controlState.value)
 
@@ -328,6 +337,11 @@ internal class CoroutineScheduler(
         if (requests == 0) return false
         assert { requests > 0 }
         return cpuDecompensationRequests.compareAndSet(requests, requests - 1)
+    }
+
+    private inline fun tryDecrementOutstandingCpuCompensations(): Boolean = outstandingCpuCompensations.loop { outstanding ->
+        if (outstanding == 0) return false
+        if (outstandingCpuCompensations.compareAndSet(outstanding, outstanding - 1)) return true
     }
 
     // This is used a "stop signal" for close and shutdown functions
@@ -368,6 +382,11 @@ internal class CoroutineScheduler(
     fun shutdown(timeout: Long) {
         // atomically set termination flag which is checked when workers are added or removed
         if (!_isTerminated.compareAndSet(false, true)) return
+
+        while (outstandingCpuCompensations.value > 0) {
+            decreaseCpuParallelism()
+        }
+
         // make sure we are not waiting for the current thread
         val currentWorker = currentWorker()
         // Capture # of created workers that cannot change anymore (mind the synchronized block!)
@@ -602,6 +621,41 @@ internal class CoroutineScheduler(
             "blocking tasks = ${blockingTasks(state)}, " +
             "CPUs acquired = ${corePoolSize - availableCpuPermits(state)}" +
             "}]"
+    }
+
+    fun increaseCpuParallelism() {
+        if (isTerminated) return
+        if (tryDecrementDecompensationRequests()) {
+            // instead of increasing the parallelism limit, we removed a request to decrease it
+        } else {
+            outstandingCpuCompensations.incrementAndGet()
+            releaseCpuPermit()
+        }
+        signalCpuWork()
+    }
+
+    /**
+     * Requests that one previously-added CPU permit (from a matching [increaseCpuParallelism] call) be given
+     * back to the pool the next time some CPU-permit-holding worker reaches a safe point
+     * (see [Worker.tryDecompensateCpu]).
+     *
+     * Floor invariant: this only has an effect if [outstandingCpuCompensations] has a spare unit, i.e. there was
+     * a genuine, not-yet-reclaimed prior [increaseCpuParallelism] call. Without this check, an unpaired call
+     * here could eventually drain [availableCpuPermits] below [corePoolSize], permanently starving the pool.
+     * If there is no such unit, this call is a safe no-op.
+     *
+     * Known, accepted conservatism: if [increaseCpuParallelism]'s cancel-a-pending-decrease branch fires for a
+     * decrease request *after* this method already consumed a unit of [outstandingCpuCompensations] for that
+     * same request, [outstandingCpuCompensations] can end up slightly under-counting real headroom (a future
+     * legitimate decrease may be refused even though it would have been safe) — this is intentionally accepted
+     * as a safety-over-liveness tradeoff, not something to engineer around.
+     */
+    fun decreaseCpuParallelism() {
+        if (tryDecrementOutstandingCpuCompensations()) {
+            if (!tryAcquireCpuPermit()) {
+                cpuDecompensationRequests.incrementAndGet()
+            }
+        }
     }
 
     /** see [Worker.runTaskSafely] */
@@ -1092,12 +1146,7 @@ internal class CoroutineScheduler(
                 // increasing the number of blocking tasks and the available cpu permits. The increase in the number
                 // of blocking tasks will make the scheduler treat the current worker as a non-CPU one.
                 incrementBlockingTasks()
-                if (tryDecrementDecompensationRequests()) {
-                    // instead of increasing the parallelism limit, we removed a request to decrease it
-                } else {
-                    releaseCpuPermit()
-                }
-                signalCpuWork()
+                increaseCpuParallelism()
             }
             val taskParallelismCompensation = (currentTask as? TaskImpl)?.block as? ParallelismCompensation
             taskParallelismCompensation?.increaseParallelismAndLimit()

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -298,8 +298,8 @@ internal class CoroutineScheduler(
 
     /**
      * Number of CPU permits added by [tryIncrementCpuParallelism] calls that have not
-     * yet been reclaimed by a matching [tryDecreaseCpuParallelism] call. Acts as a safe-mechanism that guarantees
-     * that [outstandingCpuCompensations] is in the 0..[MAX_OUTSTANDING_CPU_COMPENSATIONS] range.
+     * yet been reclaimed by a matching [tryDecreaseCpuParallelism] call. Acts as a safety mechanism that
+     * guarantees this counter stays within the 0..[MAX_OUTSTANDING_CPU_COMPENSATIONS] range.
      */
     private val outstandingCpuCompensations = atomic(0)
 
@@ -627,13 +627,13 @@ internal class CoroutineScheduler(
     }
 
     /**
-     * Increase the amount of allowed CPU threads.
+     * Increases the amount of allowed CPU threads.
      *
-     * The amount of compensated threads can not be exceed [MAX_OUTSTANDING_CPU_COMPENSATIONS]
+     * The amount of compensated threads cannot exceed [MAX_OUTSTANDING_CPU_COMPENSATIONS].
      *
-     * Mechanism of cpu compensation is a part of IntelliJ-patch, and has not been tested for
-     * all corner cases such as [corePoolSize] = [MAX_SUPPORTED_POOL_SIZE], where integer overflow
-     * is possible
+     * The CPU compensation mechanism is part of the IntelliJ patch and has not been tested for
+     * all corner cases, such as [corePoolSize] == [MAX_SUPPORTED_POOL_SIZE], where an integer overflow
+     * is possible.
      */
     fun tryIncrementCpuParallelism(): Boolean {
         if (isTerminated) return false
@@ -645,11 +645,11 @@ internal class CoroutineScheduler(
             }
             releaseCpuPermit()
 
-            // CPU workers are counted as `number of workers - number of blocking tasks`
-            // New cpu worker can be allocated only if there is less cpu workers than [corePoolSize]
-            // [corePoolSize] is a constant value, and change it may lead to unexpected bugs
-            // Fakely increment number of blocking tasks, to artificially decrease the number
-            // of cpu workers.
+            // CPU workers are counted as `number of workers - number of blocking tasks`.
+            // A new CPU worker can be allocated only if there are fewer CPU workers than [corePoolSize].
+            // [corePoolSize] is a constant value, and changing it may lead to unexpected bugs.
+            // Artificially increment the number of blocking tasks to decrease the number
+            // of CPU workers.
             incrementBlockingTasks() // Fake blocking tasks to hack cpuWorkers
         }
         signalCpuWork()
@@ -657,23 +657,23 @@ internal class CoroutineScheduler(
     }
 
     /**
-     * Decrease the amount of allowed CPU threads.
-     * Can not decrease the amount below than initial [corePoolSize], in this case
+     * Decreases the amount of allowed CPU threads.
+     * Cannot decrease the amount below the initial [corePoolSize]; in this case
      * the function does nothing and returns `false`.
      *
-     * This function is a part of IntelliJ-patch
+     * This function is part of the IntelliJ patch.
      */
     fun tryDecreaseCpuParallelism(): Boolean {
         if (!tryDecrementOutstandingCpuCompensations()) return false
         if (!tryAcquireCpuPermit()) {
             cpuDecompensationRequests.incrementAndGet()
         }
-        // Cpu permit is acquired, which decreases available cpu permits
-        // Artificially decrease the number of blocking taks, to correctly calculate
-        // number of cpu workers. See [increaseCpuParallelism] for more details.
-        // Blocking tasks can not go below 0, cpu parallelism can decrease only when there
-        // is an outstanding cpu compensation. So for every blocking task decrement there is
-        // a matching incrementBlockingTasks done in [increasingCpuParallelism]
+        // A CPU permit is acquired, which decreases the available CPU permits.
+        // Artificially decrease the number of blocking tasks, to correctly calculate
+        // the number of CPU workers. See [tryIncrementCpuParallelism] for more details.
+        // Blocking tasks cannot go below 0: CPU parallelism can decrease only when there
+        // is an outstanding CPU compensation, so for every blocking task decrement there is
+        // a matching incrementBlockingTasks() call done in [tryIncrementCpuParallelism].
         decrementBlockingTasks()
         return true
     }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/CoroutineScheduler.kt
@@ -657,10 +657,7 @@ internal class CoroutineScheduler(
     fun tryIncreaseCpuParallelism(): Boolean = synchronized(compensationLock) {
         if (isTerminated) return false
 
-        // Disable adjustment in extreme cases where corePoolSize or maxPoolSize are large enough to risk overflow
-        if (corePoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE ||
-            maxPoolSize + MAX_OUTSTANDING_CPU_COMPENSATIONS > MAX_SUPPORTED_POOL_SIZE ||
-            outstandingCpuCompensations >= MAX_OUTSTANDING_CPU_COMPENSATIONS ||
+        if (outstandingCpuCompensations >= MAX_OUTSTANDING_CPU_COMPENSATIONS ||
             outstandingCpuCompensations >= maxPoolSize - corePoolSize) {
             return false
         }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -177,17 +177,17 @@ internal open class SchedulerCoroutineDispatcher(
     }
 
     override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
-        fun Boolean.toInt() = if (this) 1 else 0
+        fun Boolean.toByte() = if (this) 1 else 0
 
         val delta = parallelismDelta.toInt()
         if (delta > 0) {
             return (1..delta).sumOf {
-                coroutineScheduler.tryIncreaseCpuParallelism().toInt()
+                coroutineScheduler.tryIncreaseCpuParallelism().toByte()
             }.toByte()
         }
         if (delta < 0) {
             val successfulAdjustments = (1..-delta).sumOf {
-                coroutineScheduler.tryDecreaseCpuParallelism().toInt()
+                coroutineScheduler.tryDecreaseCpuParallelism().toByte()
             }
             return (-successfulAdjustments).toByte()
         }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -63,7 +63,7 @@ private object UnlimitedIoScheduler : CoroutineDispatcher(), SoftLimitedParallel
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
         // Do nothing, because it is unlimited
         return 0
     }
@@ -109,7 +109,7 @@ internal object DefaultIoScheduler : ExecutorCoroutineDispatcher(), Executor, So
 
     override fun toString(): String = "Dispatchers.IO"
 
-    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
         return default.tryAdjustParallelism(parallelismDelta)
     }
 }
@@ -176,20 +176,19 @@ internal open class SchedulerCoroutineDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
-        fun Boolean.toByte() = if (this) 1 else 0
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+        fun Boolean.toInt() = if (this) 1 else 0
 
-        val delta = parallelismDelta.toInt()
-        if (delta > 0) {
-            return (1..delta).sumOf {
-                coroutineScheduler.tryIncreaseCpuParallelism().toByte()
-            }.toByte()
-        }
-        if (delta < 0) {
-            val successfulAdjustments = (1..-delta).sumOf {
-                coroutineScheduler.tryDecreaseCpuParallelism().toByte()
+        if (parallelismDelta > 0) {
+            return (1..parallelismDelta).sumOf {
+                coroutineScheduler.tryIncreaseCpuParallelism().toInt()
             }
-            return (-successfulAdjustments).toByte()
+        }
+        if (parallelismDelta < 0) {
+            val successfulAdjustments = (1..-parallelismDelta).sumOf {
+                coroutineScheduler.tryDecreaseCpuParallelism().toInt()
+            }
+            return -successfulAdjustments
         }
         return 0
     }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -63,7 +63,7 @@ private object UnlimitedIoScheduler : CoroutineDispatcher(), SoftLimitedParallel
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
         // Do nothing, because it is unlimited
         return 0
     }
@@ -109,7 +109,7 @@ internal object DefaultIoScheduler : ExecutorCoroutineDispatcher(), Executor, So
 
     override fun toString(): String = "Dispatchers.IO"
 
-    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
         return default.tryAdjustParallelism(parallelismDelta)
     }
 }
@@ -176,19 +176,20 @@ internal open class SchedulerCoroutineDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+    override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
         fun Boolean.toInt() = if (this) 1 else 0
 
-        if (parallelismDelta > 0) {
-            return (1..parallelismDelta).sumOf {
+        val delta = parallelismDelta.toInt()
+        if (delta > 0) {
+            return (1..delta).sumOf {
                 coroutineScheduler.tryIncreaseCpuParallelism().toInt()
-            }
+            }.toByte()
         }
-        if (parallelismDelta < 0) {
-            val successfulAdjustments = (1..-parallelismDelta).sumOf {
+        if (delta < 0) {
+            val successfulAdjustments = (1..-delta).sumOf {
                 coroutineScheduler.tryDecreaseCpuParallelism().toInt()
             }
-            return -successfulAdjustments
+            return (-successfulAdjustments).toByte()
         }
         return 0
     }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -176,7 +176,6 @@ internal open class SchedulerCoroutineDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-
     override fun tryAdjustParallelism(parallelismDelta: Int): Int {
         // Stop adjustment after first failed adjustment
         fun repeatWhileTrue(times: Int, adjustment: () -> Boolean): Int {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -181,7 +181,7 @@ internal open class SchedulerCoroutineDispatcher(
 
         if (parallelismDelta > 0) {
             return (1..parallelismDelta).sumOf {
-                coroutineScheduler.tryIncrementCpuParallelism().toInt()
+                coroutineScheduler.tryIncreaseCpuParallelism().toInt()
             }
         }
         if (parallelismDelta < 0) {

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -30,6 +30,7 @@ internal object DefaultScheduler : SchedulerCoroutineDispatcher(
     }
 
     override fun toString(): String = "Dispatchers.Default"
+
 }
 
 // The unlimited instance of Dispatchers.IO that utilizes all the threads CoroutineScheduler provides
@@ -61,6 +62,10 @@ private object UnlimitedIoScheduler : CoroutineDispatcher(), SoftLimitedParallel
         parallelism.checkParallelism()
         if (parallelism >= MAX_POOL_SIZE) return namedOrThis(name)
         return SoftLimitedDispatcher(this, parallelism, name)
+    }
+
+    override fun adjustParallelism(parallelism: Int) {
+        // Do nothing, because it is unlimited
     }
 }
 
@@ -103,6 +108,10 @@ internal object DefaultIoScheduler : ExecutorCoroutineDispatcher(), Executor, So
     }
 
     override fun toString(): String = "Dispatchers.IO"
+
+    override fun adjustParallelism(parallelism: Int) {
+        default.adjustParallelism(parallelism)
+    }
 }
 
 // Instantiated in tests so we can test it in isolation
@@ -165,5 +174,9 @@ internal open class SchedulerCoroutineDispatcher(
         parallelism.checkParallelism()
         if (parallelism >= corePoolSize) return namedOrThis(name)
         return SoftLimitedDispatcher(this, parallelism, name)
+    }
+
+    override fun adjustParallelism(parallelism: Int) {
+        TODO("Not yet implemented")
     }
 }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -63,8 +63,9 @@ private object UnlimitedIoScheduler : CoroutineDispatcher(), SoftLimitedParallel
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun adjustParallelism(parallelism: Int) {
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
         // Do nothing, because it is unlimited
+        return 0
     }
 }
 
@@ -108,8 +109,8 @@ internal object DefaultIoScheduler : ExecutorCoroutineDispatcher(), Executor, So
 
     override fun toString(): String = "Dispatchers.IO"
 
-    override fun adjustParallelism(parallelism: Int) {
-        default.adjustParallelism(parallelism)
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+        return default.tryAdjustParallelism(parallelismDelta)
     }
 }
 
@@ -175,12 +176,20 @@ internal open class SchedulerCoroutineDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
-    override fun adjustParallelism(parallelism: Int) {
-        if (parallelism > 0) {
-            repeat(parallelism) { coroutineScheduler.increaseCpuParallelism() }
+    override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+        fun Boolean.toInt() = if (this) 1 else 0
+
+        if (parallelismDelta > 0) {
+            return (0..parallelismDelta).sumOf {
+                coroutineScheduler.tryIncrementCpuParallelism().toInt()
+            }
         }
-        if (parallelism < 0) {
-            repeat(-parallelism) { coroutineScheduler.decreaseCpuParallelism() }
+        if (parallelismDelta < 0) {
+            val successfulAdjustments = (0..-parallelismDelta).sumOf {
+                coroutineScheduler.tryDecreaseCpuParallelism().toInt()
+            }
+            return -successfulAdjustments
         }
+        return 0
     }
 }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -176,18 +176,28 @@ internal open class SchedulerCoroutineDispatcher(
         return SoftLimitedDispatcher(this, parallelism, name)
     }
 
+
     override fun tryAdjustParallelism(parallelismDelta: Int): Int {
-        fun Boolean.toInt() = if (this) 1 else 0
+        // Stop adjustment after first failed adjustment
+        fun repeatWhileTrue(times: Int, adjustment: () -> Boolean): Int {
+            var applied = 0
+            while (applied < times) {
+                if (!adjustment()) break
+                applied++
+            }
+            return applied
+        }
 
         if (parallelismDelta > 0) {
-            return (1..parallelismDelta).sumOf {
-                coroutineScheduler.tryIncreaseCpuParallelism().toInt()
-            }
+            return repeatWhileTrue(parallelismDelta, {
+                coroutineScheduler.tryIncreaseCpuParallelism()
+            })
         }
         if (parallelismDelta < 0) {
-            val successfulAdjustments = (1..-parallelismDelta).sumOf {
-                coroutineScheduler.tryDecreaseCpuParallelism().toInt()
-            }
+            val successfulAdjustments = repeatWhileTrue(
+                -parallelismDelta.coerceAtLeast(Int.MIN_VALUE + 1),
+                { coroutineScheduler.tryDecreaseCpuParallelism() }
+            )
             return -successfulAdjustments
         }
         return 0

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -180,12 +180,12 @@ internal open class SchedulerCoroutineDispatcher(
         fun Boolean.toInt() = if (this) 1 else 0
 
         if (parallelismDelta > 0) {
-            return (0..parallelismDelta).sumOf {
+            return (1..parallelismDelta).sumOf {
                 coroutineScheduler.tryIncrementCpuParallelism().toInt()
             }
         }
         if (parallelismDelta < 0) {
-            val successfulAdjustments = (0..-parallelismDelta).sumOf {
+            val successfulAdjustments = (1..-parallelismDelta).sumOf {
                 coroutineScheduler.tryDecreaseCpuParallelism().toInt()
             }
             return -successfulAdjustments

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -177,6 +177,11 @@ internal open class SchedulerCoroutineDispatcher(
     }
 
     override fun adjustParallelism(parallelism: Int) {
-        TODO("Not yet implemented")
+        if (parallelism > 0) {
+            repeat(parallelism) { coroutineScheduler.increaseCpuParallelism() }
+        }
+        if (parallelism < 0) {
+            repeat(-parallelism) { coroutineScheduler.decreaseCpuParallelism() }
+        }
     }
 }

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Dispatcher.kt
@@ -30,7 +30,6 @@ internal object DefaultScheduler : SchedulerCoroutineDispatcher(
     }
 
     override fun toString(): String = "Dispatchers.Default"
-
 }
 
 // The unlimited instance of Dispatchers.IO that utilizes all the threads CoroutineScheduler provides

--- a/kotlinx-coroutines-core/jvm/src/scheduling/Tasks.kt
+++ b/kotlinx-coroutines-core/jvm/src/scheduling/Tasks.kt
@@ -45,6 +45,17 @@ internal val IDLE_WORKER_KEEP_ALIVE_NS = TimeUnit.SECONDS.toNanos(
     systemProp("kotlinx.coroutines.scheduler.keep.alive.sec", 60L)
 )
 
+/**
+ * IntelliJ patch: the maximum number of outstanding [CoroutineScheduler.tryIncreaseCpuParallelism] calls
+ * that have not yet been reclaimed by a matching [CoroutineScheduler.tryDecreaseCpuParallelism] call.
+ */
+@JvmField
+internal val MAX_OUTSTANDING_CPU_COMPENSATIONS = systemProp(
+    "kotlinx.coroutines.scheduler.max.outstanding.cpu.compensations",
+    1024,
+    minValue = 0
+)
+
 @JvmField
 internal var schedulerTimeSource: SchedulerTimeSource = NanoTimeSource
 

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -40,10 +40,16 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(0, scheduler.createdWorkersSnapshot())
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
-            assertTrue(scheduler.tryIncrementCpuParallelism(), "tryIncrementCpuParallelism() should succeed when there is room to grow")
+            assertTrue(
+                scheduler.tryIncrementCpuParallelism(),
+                "tryIncrementCpuParallelism() should succeed when there is room to grow"
+            )
 
             assertEquals(1, scheduler.createdWorkersSnapshot())
-            assertEquals(corePoolSize + 1, scheduler.availableCpuPermitsSnapshot())
+            // The new worker's startup scan transiently holds the freed permit while it looks for
+            // a task (there is none), then releases it and parks -- so the permit count only
+            // settles at corePoolSize + 1 once that scan finishes, not synchronously here.
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
             awaitCondition { scheduler.liveWorkerThreads().isNotEmpty() }
         }
     }
@@ -53,7 +59,10 @@ class CpuParallelismControlTest : TestBase() {
         val corePoolSize = 1
         val scheduler = CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "Terminated")
         scheduler.close()
-        assertFalse(scheduler.tryIncrementCpuParallelism(), "tryIncrementCpuParallelism() must fail once the scheduler is terminated")
+        assertFalse(
+            scheduler.tryIncrementCpuParallelism(),
+            "tryIncrementCpuParallelism() must fail once the scheduler is terminated"
+        )
     }
 
     @Test
@@ -155,50 +164,6 @@ class CpuParallelismControlTest : TestBase() {
         }
     }
 
-    @Test
-    fun testDecreaseCpuParallelismGoesThroughDecompensationRequestWhenNoPermitIsFree() {
-        val corePoolSize = 1
-        CoroutineScheduler(corePoolSize, corePoolSize + 1, schedulerName = "DecreaseViaRequest").use { scheduler ->
-            val started1 = CountDownLatch(1)
-            val release1 = CountDownLatch(1)
-            scheduler.dispatch(Runnable {
-                started1.countDown()
-                release1.await()
-            })
-            assertTrue(started1.await(10, TimeUnit.SECONDS))
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
-
-            // Ask the worker running task1, from this thread, to compensate for going into a
-            // blocking wait -- the same cross-thread ParallelismCompensation trick production
-            // watchdogs use. This marks the worker as non-CPU (opening a slot for a replacement
-            // CPU worker) and grants one genuine extra permit via increaseCpuParallelism(), while
-            // the worker itself keeps holding onto its own original permit throughout.
-            val worker1 = scheduler.liveWorkerThreads().single()
-            (worker1 as ParallelismCompensation).increaseParallelismAndLimit()
-
-            // The freed-up slot lets a second worker spin up and claim the newly granted permit
-            // for a second busy task, so both the original and the extra permit end up genuinely
-            // held at the same time.
-            val started2 = CountDownLatch(1)
-            val release2 = CountDownLatch(1)
-            scheduler.dispatch(Runnable {
-                started2.countDown()
-                release2.await()
-            })
-            assertTrue(started2.await(10, TimeUnit.SECONDS))
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
-
-            // No permit is free right now, so decreaseCpuParallelism() can't steal one in place
-            // and must fall back to registering a decompensation request instead. It still
-            // succeeds because there is a genuine outstanding compensation (granted above via
-            // increaseParallelismAndLimit()) for it to claim.
-            assertTrue(scheduler.tryDecreaseCpuParallelism())
-
-            release1.countDown()
-            release2.countDown()
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
-        }
-    }
 
     @Test
     fun testShutdownWithUnclaimedOutstandingCompensationDoesNotHang() {
@@ -213,49 +178,10 @@ class CpuParallelismControlTest : TestBase() {
             val shutdownThread = Thread { scheduler.close() }
             shutdownThread.start()
             shutdownThread.join(10_000)
-            assertFalse(shutdownThread.isAlive, "shutdown() did not complete in time -- likely hung draining outstandingCpuCompensations")
-        }
-    }
-
-    @Test
-    fun testShutdownWithDecompensationRequestDuringDrainSettlesAtCorePoolSize() {
-        val corePoolSize = 1
-        CoroutineScheduler(corePoolSize, corePoolSize + 1, schedulerName = "ShutdownViaRequest").use { scheduler ->
-            val started1 = CountDownLatch(1)
-            val release1 = CountDownLatch(1)
-            scheduler.dispatch(Runnable {
-                started1.countDown()
-                release1.await()
-            })
-            assertTrue(started1.await(10, TimeUnit.SECONDS))
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
-
-            // Same cross-thread compensation trick as above: grants one genuine extra permit that
-            // a second busy worker then actively claims, so both permits are held when shutdown()
-            // starts -- forcing its internal drain loop through the decompensation-request
-            // fallback rather than an in-place decrement.
-            val worker1 = scheduler.liveWorkerThreads().single()
-            (worker1 as ParallelismCompensation).increaseParallelismAndLimit()
-
-            val started2 = CountDownLatch(1)
-            val release2 = CountDownLatch(1)
-            scheduler.dispatch(Runnable {
-                started2.countDown()
-                release2.await()
-            })
-            assertTrue(started2.await(10, TimeUnit.SECONDS))
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
-
-            // Start shutdown while both permits are still held, then let the busy workers finish
-            // so shutdown's forced worker termination can settle the registered decompensation
-            // request, same as it would for a normal task completion.
-            val shutdownThread = Thread { scheduler.close() }
-            shutdownThread.start()
-            release1.countDown()
-            release2.countDown()
-
-            shutdownThread.join(10_000)
-            assertFalse(shutdownThread.isAlive, "shutdown() did not complete in time")
+            assertFalse(
+                shutdownThread.isAlive,
+                "shutdown() did not complete in time -- likely hung draining outstandingCpuCompensations"
+            )
         }
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -164,6 +164,56 @@ class CpuParallelismControlTest : TestBase() {
         }
     }
 
+    @Test
+    fun testIncreaseCpuParallelismCannotExceedMaxOutstandingCompensations() {
+        val corePoolSize = 1
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "MaxOutstandingCompensations").use { scheduler ->
+            repeat(MAX_OUTSTANDING_CPU_COMPENSATIONS) {
+                assertTrue(
+                    scheduler.tryIncreaseCpuParallelism(),
+                    "compensation #$it should be within the configured limit of $MAX_OUTSTANDING_CPU_COMPENSATIONS"
+                )
+            }
+
+            assertFalse(
+                scheduler.tryIncreaseCpuParallelism(),
+                "must not allow more than $MAX_OUTSTANDING_CPU_COMPENSATIONS outstanding compensations at once"
+            )
+        }
+    }
+
+    @Test
+    fun testConcurrentIncreaseAndDecreaseCpuParallelismDoNotObserveTornCompensationState() {
+        val corePoolSize = 1
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "IncreaseDecreaseRace").use { scheduler ->
+            val executor = Executors.newFixedThreadPool(2)
+            try {
+                repeat(5_000 * stressTestMultiplierSqrt) {
+                    val barrier = CyclicBarrier(2)
+                    val increaseFuture = executor.submit(Callable {
+                        barrier.await(10, TimeUnit.SECONDS)
+                        scheduler.tryIncreaseCpuParallelism()
+                    })
+                    val decreaseFuture = executor.submit(Callable {
+                        barrier.await(10, TimeUnit.SECONDS)
+                        scheduler.tryDecreaseCpuParallelism()
+                    })
+                    // .get() rethrows any exception (in particular the AssertionError described above) that
+                    // was thrown inside the racing calls.
+                    increaseFuture.get(10, TimeUnit.SECONDS)
+                    decreaseFuture.get(10, TimeUnit.SECONDS)
+                }
+
+                // Drain whatever net compensation this round-robin left outstanding, then confirm the pool
+                // settled back to its baseline -- catches silent controlState corruption even if no single
+                // interleaving happened to trip the assertion above.
+                while (scheduler.tryDecreaseCpuParallelism()) { /* drain */ }
+                awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
+            } finally {
+                executor.shutdown()
+            }
+        }
+    }
 
     @Test
     fun testShutdownWithUnclaimedOutstandingCompensationDoesNotHang() {

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -171,7 +171,7 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testIncreaseCpuParallelismCannotExceedMaxOutstandingCompensations() {
         val corePoolSize = 1
-        val maxPoolSize = CoroutineScheduler.MAX_SUPPORTED_POOL_SIZE - MAX_OUTSTANDING_CPU_COMPENSATIONS - 20
+        val maxPoolSize = CoroutineScheduler.MAX_SUPPORTED_POOL_SIZE
         CoroutineScheduler(corePoolSize, maxPoolSize, schedulerName = "MaxOutstandingCompensations").use { scheduler ->
             repeat(MAX_OUTSTANDING_CPU_COMPENSATIONS) {
                 assertTrue(

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -41,7 +41,7 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             assertTrue(
-                scheduler.tryIncrementCpuParallelism(),
+                scheduler.tryIncreaseCpuParallelism(),
                 "tryIncrementCpuParallelism() should succeed when there is room to grow"
             )
 
@@ -60,7 +60,7 @@ class CpuParallelismControlTest : TestBase() {
         val scheduler = CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "Terminated")
         scheduler.close()
         assertFalse(
-            scheduler.tryIncrementCpuParallelism(),
+            scheduler.tryIncreaseCpuParallelism(),
             "tryIncrementCpuParallelism() must fail once the scheduler is terminated"
         )
     }
@@ -82,7 +82,7 @@ class CpuParallelismControlTest : TestBase() {
             assertTrue(started.await(10, TimeUnit.SECONDS))
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
 
-            assertTrue(scheduler.tryIncrementCpuParallelism())
+            assertTrue(scheduler.tryIncreaseCpuParallelism())
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 1 }
 
             // Prove the increase is a real, reclaimable credit (not just a transient bump): a matching
@@ -102,7 +102,7 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             val n = 3
-            repeat(n) { assertTrue(scheduler.tryIncrementCpuParallelism()) }
+            repeat(n) { assertTrue(scheduler.tryIncreaseCpuParallelism()) }
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + n }
 
             repeat(n) {
@@ -152,7 +152,7 @@ class CpuParallelismControlTest : TestBase() {
 
             // Nothing is using the pool, so the permit increaseCpuParallelism() grants here is
             // never claimed by any worker -- it just sits free.
-            assertTrue(scheduler.tryIncrementCpuParallelism())
+            assertTrue(scheduler.tryIncreaseCpuParallelism())
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
 
             // With a free permit available, decreaseCpuParallelism() should steal it back via
@@ -172,7 +172,7 @@ class CpuParallelismControlTest : TestBase() {
             // Leaves outstandingCpuCompensations == 1 with nobody ever having claimed the extra
             // permit -- shutdown() must drain this itself before its availableCpuPermits ==
             // corePoolSize assertion, via decreaseCpuParallelism().
-            assertTrue(scheduler.tryIncrementCpuParallelism())
+            assertTrue(scheduler.tryIncreaseCpuParallelism())
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
 
             val shutdownThread = Thread { scheduler.close() }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -42,7 +42,7 @@ class CpuParallelismControlTest : TestBase() {
 
             assertTrue(
                 scheduler.tryIncreaseCpuParallelism(),
-                "tryIncrementCpuParallelism() should succeed when there is room to grow"
+                "tryIncreaseCpuParallelism() should succeed when there is room to grow"
             )
 
             assertEquals(1, scheduler.createdWorkersSnapshot())
@@ -61,7 +61,7 @@ class CpuParallelismControlTest : TestBase() {
         scheduler.close()
         assertFalse(
             scheduler.tryIncreaseCpuParallelism(),
-            "tryIncrementCpuParallelism() must fail once the scheduler is terminated"
+            "tryIncreaseCpuParallelism() must fail once the scheduler is terminated"
         )
     }
 

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -36,7 +36,7 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testIncreaseCpuParallelismCreatesWorkerFromZero() {
         val corePoolSize = 1
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "IncreaseFromZero").use { scheduler ->
+        CoroutineScheduler(corePoolSize, corePoolSize * 5, schedulerName = "IncreaseFromZero").use { scheduler ->
             assertEquals(0, scheduler.createdWorkersSnapshot())
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
@@ -68,7 +68,7 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testIncreaseCpuParallelismWhenAllPermitsHeld() {
         val corePoolSize = 2
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "IncreaseAllHeld").use { scheduler ->
+        CoroutineScheduler(corePoolSize, corePoolSize * 2, schedulerName = "IncreaseAllHeld").use { scheduler ->
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             val started = CountDownLatch(corePoolSize)
@@ -79,17 +79,20 @@ class CpuParallelismControlTest : TestBase() {
                     release.await()
                 })
             }
-            assertTrue(started.await(10, TimeUnit.SECONDS))
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
+            try {
+                assertTrue(started.await(10, TimeUnit.SECONDS))
+                awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
 
-            assertTrue(scheduler.tryIncreaseCpuParallelism())
-            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 1 }
+                assertTrue(scheduler.tryIncreaseCpuParallelism())
+                awaitCondition { scheduler.availableCpuPermitsSnapshot() == 1 }
 
-            // Prove the increase is a real, reclaimable credit (not just a transient bump): a matching
-            // decrease consumes it, and once the busy workers finish, the pool settles exactly back at
-            // corePoolSize rather than corePoolSize + 1.
-            assertTrue(scheduler.tryDecreaseCpuParallelism())
-            release.countDown()
+                // Prove the increase is a real, reclaimable credit (not just a transient bump): a matching
+                // decrease consumes it, and once the busy workers finish, the pool settles exactly back at
+                // corePoolSize rather than corePoolSize + 1.
+                assertTrue(scheduler.tryDecreaseCpuParallelism())
+            } finally {
+                release.countDown()
+            }
 
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
         }
@@ -98,7 +101,8 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testIncreaseThenDecreaseCpuParallelismRoundTrip() {
         val corePoolSize = 2
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "RoundTrip").use { scheduler ->
+        val maxPoolSize = 20
+        CoroutineScheduler(corePoolSize, maxPoolSize, schedulerName = "RoundTrip").use { scheduler ->
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             val n = 3
@@ -147,7 +151,7 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testDecreaseCpuParallelismInPlaceWhenPermitIsFree() {
         val corePoolSize = 2
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "DecreaseInPlace").use { scheduler ->
+        CoroutineScheduler(corePoolSize, corePoolSize * 5, schedulerName = "DecreaseInPlace").use { scheduler ->
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             // Nothing is using the pool, so the permit increaseCpuParallelism() grants here is
@@ -167,7 +171,8 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testIncreaseCpuParallelismCannotExceedMaxOutstandingCompensations() {
         val corePoolSize = 1
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "MaxOutstandingCompensations").use { scheduler ->
+        val maxPoolSize = CoroutineScheduler.MAX_SUPPORTED_POOL_SIZE - MAX_OUTSTANDING_CPU_COMPENSATIONS - 20
+        CoroutineScheduler(corePoolSize, maxPoolSize, schedulerName = "MaxOutstandingCompensations").use { scheduler ->
             repeat(MAX_OUTSTANDING_CPU_COMPENSATIONS) {
                 assertTrue(
                     scheduler.tryIncreaseCpuParallelism(),
@@ -218,7 +223,7 @@ class CpuParallelismControlTest : TestBase() {
     @Test
     fun testShutdownWithUnclaimedOutstandingCompensationDoesNotHang() {
         val corePoolSize = 2
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "ShutdownUnclaimed").use { scheduler ->
+        CoroutineScheduler(corePoolSize, corePoolSize * 2, schedulerName = "ShutdownUnclaimed").use { scheduler ->
             // Leaves outstandingCpuCompensations == 1 with nobody ever having claimed the extra
             // permit -- shutdown() must drain this itself before its availableCpuPermits ==
             // corePoolSize assertion, via decreaseCpuParallelism().
@@ -252,6 +257,44 @@ class CpuParallelismControlTest : TestBase() {
             assertFalse(
                 scheduler.tryIncreaseCpuParallelism(),
                 "An increase that can overflow the packed CPU-permit field must be rejected"
+            )
+        }
+    }
+
+    @Test
+    fun testIncreaseCannotExceedMaxPoolSize() {
+        val corePoolSize = 2
+        val maxPoolSize = 4
+
+        CoroutineScheduler(
+            corePoolSize = corePoolSize,
+            maxPoolSize = maxPoolSize,
+            schedulerName = "MaximumCpuParallelism"
+        ).use { scheduler ->
+            val availableHeadroom =
+                maxPoolSize - corePoolSize
+
+            repeat(availableHeadroom) {
+                assertTrue(
+                    scheduler.tryIncreaseCpuParallelism(),
+                    "Increase #$it should fit within maxPoolSize"
+                )
+            }
+
+            assertFalse(
+                scheduler.tryIncreaseCpuParallelism(),
+                "The logical CPU parallelism must not exceed maxPoolSize"
+            )
+
+            repeat(availableHeadroom) {
+                assertTrue(
+                    scheduler.tryDecreaseCpuParallelism()
+                )
+            }
+
+            assertFalse(
+                scheduler.tryDecreaseCpuParallelism(),
+                "All outstanding increases should be reclaimed"
             )
         }
     }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -40,12 +40,20 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(0, scheduler.createdWorkersSnapshot())
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
-            scheduler.tryIncrementCpuParallelism()
+            assertTrue(scheduler.tryIncrementCpuParallelism(), "tryIncrementCpuParallelism() should succeed when there is room to grow")
 
             assertEquals(1, scheduler.createdWorkersSnapshot())
             assertEquals(corePoolSize + 1, scheduler.availableCpuPermitsSnapshot())
             awaitCondition { scheduler.liveWorkerThreads().isNotEmpty() }
         }
+    }
+
+    @Test
+    fun testIncreaseCpuParallelismFailsAfterTermination() {
+        val corePoolSize = 1
+        val scheduler = CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "Terminated")
+        scheduler.close()
+        assertFalse(scheduler.tryIncrementCpuParallelism(), "tryIncrementCpuParallelism() must fail once the scheduler is terminated")
     }
 
     @Test
@@ -65,13 +73,13 @@ class CpuParallelismControlTest : TestBase() {
             assertTrue(started.await(10, TimeUnit.SECONDS))
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
 
-            scheduler.tryIncrementCpuParallelism()
+            assertTrue(scheduler.tryIncrementCpuParallelism())
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 1 }
 
             // Prove the increase is a real, reclaimable credit (not just a transient bump): a matching
             // decrease consumes it, and once the busy workers finish, the pool settles exactly back at
             // corePoolSize rather than corePoolSize + 1.
-            scheduler.tryDecreaseCpuParallelism()
+            assertTrue(scheduler.tryDecreaseCpuParallelism())
             release.countDown()
 
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
@@ -85,11 +93,11 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             val n = 3
-            repeat(n) { scheduler.tryIncrementCpuParallelism() }
+            repeat(n) { assertTrue(scheduler.tryIncrementCpuParallelism()) }
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + n }
 
             repeat(n) {
-                scheduler.tryDecreaseCpuParallelism()
+                assertTrue(scheduler.tryDecreaseCpuParallelism())
                 // Drive a trivial completed non-blocking task so some CPU-permit-holding worker calls
                 // tryDecompensateCpu() right after running it.
                 val latch = CountDownLatch(1)
@@ -106,8 +114,8 @@ class CpuParallelismControlTest : TestBase() {
         val corePoolSize = 2
         CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "FloorInvariant").use { scheduler ->
             // No prior increaseCpuParallelism() calls -> zero legitimate headroom, so every one of these
-            // should be a no-op.
-            repeat(corePoolSize + 3) { scheduler.tryDecreaseCpuParallelism() }
+            // should be a no-op, as reported by its own return value.
+            repeat(corePoolSize + 3) { assertFalse(scheduler.tryDecreaseCpuParallelism()) }
 
             // Drive corePoolSize workers to actually acquire and then relinquish their CPU permits, so that
             // any (incorrectly) accepted decompensation requests get a chance to permanently drain permits.
@@ -135,13 +143,13 @@ class CpuParallelismControlTest : TestBase() {
 
             // Nothing is using the pool, so the permit increaseCpuParallelism() grants here is
             // never claimed by any worker -- it just sits free.
-            scheduler.tryIncrementCpuParallelism()
+            assertTrue(scheduler.tryIncrementCpuParallelism())
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
 
             // With a free permit available, decreaseCpuParallelism() should steal it back via
             // tryAcquireCpuPermit() synchronously, with no need for any worker to complete a task
             // or to go through cpuDecompensationRequests.
-            scheduler.tryDecreaseCpuParallelism()
+            assertTrue(scheduler.tryDecreaseCpuParallelism())
 
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
         }
@@ -181,8 +189,10 @@ class CpuParallelismControlTest : TestBase() {
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
 
             // No permit is free right now, so decreaseCpuParallelism() can't steal one in place
-            // and must fall back to registering a decompensation request instead.
-            scheduler.tryDecreaseCpuParallelism()
+            // and must fall back to registering a decompensation request instead. It still
+            // succeeds because there is a genuine outstanding compensation (granted above via
+            // increaseParallelismAndLimit()) for it to claim.
+            assertTrue(scheduler.tryDecreaseCpuParallelism())
 
             release1.countDown()
             release2.countDown()
@@ -197,7 +207,7 @@ class CpuParallelismControlTest : TestBase() {
             // Leaves outstandingCpuCompensations == 1 with nobody ever having claimed the extra
             // permit -- shutdown() must drain this itself before its availableCpuPermits ==
             // corePoolSize assertion, via decreaseCpuParallelism().
-            scheduler.tryIncrementCpuParallelism()
+            assertTrue(scheduler.tryIncrementCpuParallelism())
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
 
             val shutdownThread = Thread { scheduler.close() }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -40,7 +40,7 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(0, scheduler.createdWorkersSnapshot())
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
-            scheduler.increaseCpuParallelism()
+            scheduler.tryIncrementCpuParallelism()
 
             assertEquals(1, scheduler.createdWorkersSnapshot())
             assertEquals(corePoolSize + 1, scheduler.availableCpuPermitsSnapshot())
@@ -65,13 +65,13 @@ class CpuParallelismControlTest : TestBase() {
             assertTrue(started.await(10, TimeUnit.SECONDS))
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
 
-            scheduler.increaseCpuParallelism()
+            scheduler.tryIncrementCpuParallelism()
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == 1 }
 
             // Prove the increase is a real, reclaimable credit (not just a transient bump): a matching
             // decrease consumes it, and once the busy workers finish, the pool settles exactly back at
             // corePoolSize rather than corePoolSize + 1.
-            scheduler.decreaseCpuParallelism()
+            scheduler.tryDecreaseCpuParallelism()
             release.countDown()
 
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
@@ -85,11 +85,11 @@ class CpuParallelismControlTest : TestBase() {
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
 
             val n = 3
-            repeat(n) { scheduler.increaseCpuParallelism() }
+            repeat(n) { scheduler.tryIncrementCpuParallelism() }
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + n }
 
             repeat(n) {
-                scheduler.decreaseCpuParallelism()
+                scheduler.tryDecreaseCpuParallelism()
                 // Drive a trivial completed non-blocking task so some CPU-permit-holding worker calls
                 // tryDecompensateCpu() right after running it.
                 val latch = CountDownLatch(1)
@@ -107,7 +107,7 @@ class CpuParallelismControlTest : TestBase() {
         CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "FloorInvariant").use { scheduler ->
             // No prior increaseCpuParallelism() calls -> zero legitimate headroom, so every one of these
             // should be a no-op.
-            repeat(corePoolSize + 3) { scheduler.decreaseCpuParallelism() }
+            repeat(corePoolSize + 3) { scheduler.tryDecreaseCpuParallelism() }
 
             // Drive corePoolSize workers to actually acquire and then relinquish their CPU permits, so that
             // any (incorrectly) accepted decompensation requests get a chance to permanently drain permits.
@@ -135,13 +135,13 @@ class CpuParallelismControlTest : TestBase() {
 
             // Nothing is using the pool, so the permit increaseCpuParallelism() grants here is
             // never claimed by any worker -- it just sits free.
-            scheduler.increaseCpuParallelism()
+            scheduler.tryIncrementCpuParallelism()
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
 
             // With a free permit available, decreaseCpuParallelism() should steal it back via
             // tryAcquireCpuPermit() synchronously, with no need for any worker to complete a task
             // or to go through cpuDecompensationRequests.
-            scheduler.decreaseCpuParallelism()
+            scheduler.tryDecreaseCpuParallelism()
 
             assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
         }
@@ -182,7 +182,7 @@ class CpuParallelismControlTest : TestBase() {
 
             // No permit is free right now, so decreaseCpuParallelism() can't steal one in place
             // and must fall back to registering a decompensation request instead.
-            scheduler.decreaseCpuParallelism()
+            scheduler.tryDecreaseCpuParallelism()
 
             release1.countDown()
             release2.countDown()
@@ -197,7 +197,7 @@ class CpuParallelismControlTest : TestBase() {
             // Leaves outstandingCpuCompensations == 1 with nobody ever having claimed the extra
             // permit -- shutdown() must drain this itself before its availableCpuPermits ==
             // corePoolSize assertion, via decreaseCpuParallelism().
-            scheduler.increaseCpuParallelism()
+            scheduler.tryIncrementCpuParallelism()
             awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
 
             val shutdownThread = Thread { scheduler.close() }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -1,0 +1,251 @@
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.testing.*
+import org.junit.Test
+import java.lang.Runnable
+import java.util.concurrent.*
+import kotlin.test.*
+
+class CpuParallelismControlTest : TestBase() {
+
+    private fun awaitCondition(timeoutMs: Long = 5_000, intervalMs: Long = 10, condition: () -> Boolean) {
+        val deadlineNs = System.nanoTime() + timeoutMs * 1_000_000
+        while (!condition()) {
+            if (System.nanoTime() >= deadlineNs) {
+                assertTrue(condition(), "Condition not met within ${timeoutMs}ms")
+                return
+            }
+            Thread.sleep(intervalMs)
+        }
+    }
+
+    private fun CoroutineScheduler.liveWorkerThreads(): List<CoroutineScheduler.Worker> =
+        Thread.getAllStackTraces().keys.filterIsInstance<CoroutineScheduler.Worker>().filter { it.scheduler === this }
+
+    // CoroutineScheduler.toString() already reports these two figures for diagnostic/logging
+    // purposes; parsing it here avoids adding fields to production code purely for test visibility.
+    private val CREATED_WORKERS_REGEX = Regex("created workers= (\\d+)")
+    private val CPUS_ACQUIRED_REGEX = Regex("CPUs acquired = (-?\\d+)")
+
+    private fun CoroutineScheduler.createdWorkersSnapshot(): Int =
+        CREATED_WORKERS_REGEX.find(toString())!!.groupValues[1].toInt()
+
+    private fun CoroutineScheduler.availableCpuPermitsSnapshot(): Int =
+        corePoolSize - CPUS_ACQUIRED_REGEX.find(toString())!!.groupValues[1].toInt()
+
+    @Test
+    fun testIncreaseCpuParallelismCreatesWorkerFromZero() {
+        val corePoolSize = 1
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "IncreaseFromZero").use { scheduler ->
+            assertEquals(0, scheduler.createdWorkersSnapshot())
+            assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
+
+            scheduler.increaseCpuParallelism()
+
+            assertEquals(1, scheduler.createdWorkersSnapshot())
+            assertEquals(corePoolSize + 1, scheduler.availableCpuPermitsSnapshot())
+            awaitCondition { scheduler.liveWorkerThreads().isNotEmpty() }
+        }
+    }
+
+    @Test
+    fun testIncreaseCpuParallelismWhenAllPermitsHeld() {
+        val corePoolSize = 2
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "IncreaseAllHeld").use { scheduler ->
+            assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
+
+            val started = CountDownLatch(corePoolSize)
+            val release = CountDownLatch(1)
+            repeat(corePoolSize) {
+                scheduler.dispatch(Runnable {
+                    started.countDown()
+                    release.await()
+                })
+            }
+            assertTrue(started.await(10, TimeUnit.SECONDS))
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
+
+            scheduler.increaseCpuParallelism()
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 1 }
+
+            // Prove the increase is a real, reclaimable credit (not just a transient bump): a matching
+            // decrease consumes it, and once the busy workers finish, the pool settles exactly back at
+            // corePoolSize rather than corePoolSize + 1.
+            scheduler.decreaseCpuParallelism()
+            release.countDown()
+
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
+        }
+    }
+
+    @Test
+    fun testIncreaseThenDecreaseCpuParallelismRoundTrip() {
+        val corePoolSize = 2
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "RoundTrip").use { scheduler ->
+            assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
+
+            val n = 3
+            repeat(n) { scheduler.increaseCpuParallelism() }
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + n }
+
+            repeat(n) {
+                scheduler.decreaseCpuParallelism()
+                // Drive a trivial completed non-blocking task so some CPU-permit-holding worker calls
+                // tryDecompensateCpu() right after running it.
+                val latch = CountDownLatch(1)
+                scheduler.dispatch(Runnable { latch.countDown() })
+                assertTrue(latch.await(5, TimeUnit.SECONDS))
+            }
+
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
+        }
+    }
+
+    @Test
+    fun testDecreaseCpuParallelismCannotGoBelowCorePoolSize() {
+        val corePoolSize = 2
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "FloorInvariant").use { scheduler ->
+            // No prior increaseCpuParallelism() calls -> zero legitimate headroom, so every one of these
+            // should be a no-op.
+            repeat(corePoolSize + 3) { scheduler.decreaseCpuParallelism() }
+
+            // Drive corePoolSize workers to actually acquire and then relinquish their CPU permits, so that
+            // any (incorrectly) accepted decompensation requests get a chance to permanently drain permits.
+            val started = CountDownLatch(corePoolSize)
+            val release = CountDownLatch(1)
+            repeat(corePoolSize) {
+                scheduler.dispatch(Runnable {
+                    started.countDown()
+                    release.await()
+                })
+            }
+            assertTrue(started.await(10, TimeUnit.SECONDS))
+            release.countDown()
+
+            awaitCondition(timeoutMs = 3_000) { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
+            assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
+        }
+    }
+
+    @Test
+    fun testDecreaseCpuParallelismInPlaceWhenPermitIsFree() {
+        val corePoolSize = 2
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "DecreaseInPlace").use { scheduler ->
+            assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
+
+            // Nothing is using the pool, so the permit increaseCpuParallelism() grants here is
+            // never claimed by any worker -- it just sits free.
+            scheduler.increaseCpuParallelism()
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
+
+            // With a free permit available, decreaseCpuParallelism() should steal it back via
+            // tryAcquireCpuPermit() synchronously, with no need for any worker to complete a task
+            // or to go through cpuDecompensationRequests.
+            scheduler.decreaseCpuParallelism()
+
+            assertEquals(corePoolSize, scheduler.availableCpuPermitsSnapshot())
+        }
+    }
+
+    @Test
+    fun testDecreaseCpuParallelismGoesThroughDecompensationRequestWhenNoPermitIsFree() {
+        val corePoolSize = 1
+        CoroutineScheduler(corePoolSize, corePoolSize + 1, schedulerName = "DecreaseViaRequest").use { scheduler ->
+            val started1 = CountDownLatch(1)
+            val release1 = CountDownLatch(1)
+            scheduler.dispatch(Runnable {
+                started1.countDown()
+                release1.await()
+            })
+            assertTrue(started1.await(10, TimeUnit.SECONDS))
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
+
+            // Ask the worker running task1, from this thread, to compensate for going into a
+            // blocking wait -- the same cross-thread ParallelismCompensation trick production
+            // watchdogs use. This marks the worker as non-CPU (opening a slot for a replacement
+            // CPU worker) and grants one genuine extra permit via increaseCpuParallelism(), while
+            // the worker itself keeps holding onto its own original permit throughout.
+            val worker1 = scheduler.liveWorkerThreads().single()
+            (worker1 as ParallelismCompensation).increaseParallelismAndLimit()
+
+            // The freed-up slot lets a second worker spin up and claim the newly granted permit
+            // for a second busy task, so both the original and the extra permit end up genuinely
+            // held at the same time.
+            val started2 = CountDownLatch(1)
+            val release2 = CountDownLatch(1)
+            scheduler.dispatch(Runnable {
+                started2.countDown()
+                release2.await()
+            })
+            assertTrue(started2.await(10, TimeUnit.SECONDS))
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
+
+            // No permit is free right now, so decreaseCpuParallelism() can't steal one in place
+            // and must fall back to registering a decompensation request instead.
+            scheduler.decreaseCpuParallelism()
+
+            release1.countDown()
+            release2.countDown()
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
+        }
+    }
+
+    @Test
+    fun testShutdownWithUnclaimedOutstandingCompensationDoesNotHang() {
+        val corePoolSize = 2
+        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "ShutdownUnclaimed").use { scheduler ->
+            // Leaves outstandingCpuCompensations == 1 with nobody ever having claimed the extra
+            // permit -- shutdown() must drain this itself before its availableCpuPermits ==
+            // corePoolSize assertion, via decreaseCpuParallelism().
+            scheduler.increaseCpuParallelism()
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize + 1 }
+
+            val shutdownThread = Thread { scheduler.close() }
+            shutdownThread.start()
+            shutdownThread.join(10_000)
+            assertFalse(shutdownThread.isAlive, "shutdown() did not complete in time -- likely hung draining outstandingCpuCompensations")
+        }
+    }
+
+    @Test
+    fun testShutdownWithDecompensationRequestDuringDrainSettlesAtCorePoolSize() {
+        val corePoolSize = 1
+        CoroutineScheduler(corePoolSize, corePoolSize + 1, schedulerName = "ShutdownViaRequest").use { scheduler ->
+            val started1 = CountDownLatch(1)
+            val release1 = CountDownLatch(1)
+            scheduler.dispatch(Runnable {
+                started1.countDown()
+                release1.await()
+            })
+            assertTrue(started1.await(10, TimeUnit.SECONDS))
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
+
+            // Same cross-thread compensation trick as above: grants one genuine extra permit that
+            // a second busy worker then actively claims, so both permits are held when shutdown()
+            // starts -- forcing its internal drain loop through the decompensation-request
+            // fallback rather than an in-place decrement.
+            val worker1 = scheduler.liveWorkerThreads().single()
+            (worker1 as ParallelismCompensation).increaseParallelismAndLimit()
+
+            val started2 = CountDownLatch(1)
+            val release2 = CountDownLatch(1)
+            scheduler.dispatch(Runnable {
+                started2.countDown()
+                release2.await()
+            })
+            assertTrue(started2.await(10, TimeUnit.SECONDS))
+            awaitCondition { scheduler.availableCpuPermitsSnapshot() == 0 }
+
+            // Start shutdown while both permits are still held, then let the busy workers finish
+            // so shutdown's forced worker termination can settle the registered decompensation
+            // request, same as it would for a normal task completion.
+            val shutdownThread = Thread { scheduler.close() }
+            shutdownThread.start()
+            release1.countDown()
+            release2.countDown()
+
+            shutdownThread.join(10_000)
+            assertFalse(shutdownThread.isAlive, "shutdown() did not complete in time")
+        }
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -234,4 +234,25 @@ class CpuParallelismControlTest : TestBase() {
             )
         }
     }
+
+    @Test
+    fun testCpuPermitCounterDoesNotOverflowAtPackedFieldBoundary() {
+        val corePoolSize = CoroutineScheduler.MAX_SUPPORTED_POOL_SIZE
+
+        CoroutineScheduler(
+            corePoolSize = corePoolSize,
+            maxPoolSize = corePoolSize,
+            schedulerName = "PackedCounterOverflow"
+        ).use { scheduler ->
+            assertEquals(
+                corePoolSize,
+                scheduler.availableCpuPermitsSnapshot()
+            )
+
+            assertFalse(
+                scheduler.tryIncreaseCpuParallelism(),
+                "An increase that can overflow the packed CPU-permit field must be rejected"
+            )
+        }
+    }
 }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/CpuParallelismControlTest.kt
@@ -169,6 +169,7 @@ class CpuParallelismControlTest : TestBase() {
     }
 
     @Test
+    @Ignore("Creates up to 1024 native threads; run manually with sufficient resources")
     fun testIncreaseCpuParallelismCannotExceedMaxOutstandingCompensations() {
         val corePoolSize = 1
         val maxPoolSize = CoroutineScheduler.MAX_SUPPORTED_POOL_SIZE
@@ -184,39 +185,6 @@ class CpuParallelismControlTest : TestBase() {
                 scheduler.tryIncreaseCpuParallelism(),
                 "must not allow more than $MAX_OUTSTANDING_CPU_COMPENSATIONS outstanding compensations at once"
             )
-        }
-    }
-
-    @Test
-    fun testConcurrentIncreaseAndDecreaseCpuParallelismDoNotObserveTornCompensationState() {
-        val corePoolSize = 1
-        CoroutineScheduler(corePoolSize, corePoolSize, schedulerName = "IncreaseDecreaseRace").use { scheduler ->
-            val executor = Executors.newFixedThreadPool(2)
-            try {
-                repeat(5_000 * stressTestMultiplierSqrt) {
-                    val barrier = CyclicBarrier(2)
-                    val increaseFuture = executor.submit(Callable {
-                        barrier.await(10, TimeUnit.SECONDS)
-                        scheduler.tryIncreaseCpuParallelism()
-                    })
-                    val decreaseFuture = executor.submit(Callable {
-                        barrier.await(10, TimeUnit.SECONDS)
-                        scheduler.tryDecreaseCpuParallelism()
-                    })
-                    // .get() rethrows any exception (in particular the AssertionError described above) that
-                    // was thrown inside the racing calls.
-                    increaseFuture.get(10, TimeUnit.SECONDS)
-                    decreaseFuture.get(10, TimeUnit.SECONDS)
-                }
-
-                // Drain whatever net compensation this round-robin left outstanding, then confirm the pool
-                // settled back to its baseline -- catches silent controlState corruption even if no single
-                // interleaving happened to trip the assertion above.
-                while (scheduler.tryDecreaseCpuParallelism()) { /* drain */ }
-                awaitCondition { scheduler.availableCpuPermitsSnapshot() == corePoolSize }
-            } finally {
-                executor.shutdown()
-            }
         }
     }
 

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -1,0 +1,117 @@
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.internal.*
+import org.junit.Test
+import java.util.concurrent.*
+import kotlin.coroutines.*
+import kotlin.test.*
+
+/**
+ * Exercises `CoroutineDispatcher.adjustParallelism(+1)` / `(-1)` at the dispatcher level (as opposed to
+ * [CpuParallelismControlTest], which drives [CoroutineScheduler]'s increase/decrease methods directly), for
+ * both flavors of dispatcher that implement [SoftLimitedParallelism]:
+ *  - a plain [SchedulerCoroutineDispatcher] (what backs `Dispatchers.Default`)
+ *  - a [SoftLimitedDispatcher] view on top of it (what backs `Dispatchers.IO`)
+ */
+class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
+
+    @Test
+    fun testDefaultLikeDispatcherAdjustParallelismByOneLetsExtraTaskRunConcurrently() {
+        corePoolSize = 2
+        val started = CountDownLatch(corePoolSize)
+        val release = CountDownLatch(1)
+        repeat(corePoolSize) {
+            dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+                started.countDown()
+                release.await()
+            })
+        }
+        assertTrue(started.await(10, TimeUnit.SECONDS))
+
+        // All corePoolSize permits are held by the busy tasks above (which are still blocked on
+        // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
+        // new permit.
+        dispatcher.adjustParallelism(1)
+        val extraStarted = CountDownLatch(1)
+        dispatcher.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
+        assertTrue(
+            extraStarted.await(10, TimeUnit.SECONDS),
+            "adjustParallelism(1) should let one extra task run concurrently with the corePoolSize busy ones"
+        )
+
+        dispatcher.adjustParallelism(-1)
+        release.countDown()
+    }
+
+    @Test
+    fun testDefaultLikeDispatcherAdjustParallelismByMinusOneIsNoOpWithoutPriorIncrease() {
+        corePoolSize = 2
+        // No matching adjustParallelism(1) beforehand -> zero legitimate headroom, so this must not
+        // shrink the pool below corePoolSize.
+        dispatcher.adjustParallelism(-1)
+
+        val started = CountDownLatch(corePoolSize)
+        val release = CountDownLatch(1)
+        repeat(corePoolSize) {
+            dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+                started.countDown()
+                release.await()
+            })
+        }
+        assertTrue(
+            started.await(10, TimeUnit.SECONDS),
+            "adjustParallelism(-1) without a matching increase must not shrink the pool below corePoolSize"
+        )
+        release.countDown()
+    }
+
+    @Test
+    fun testIoLikeDispatcherAdjustParallelismByOneLetsExtraTaskRunConcurrently() {
+        val parallelism = 2
+        val soft = softBlockingDispatcher(parallelism)
+
+        val started = CountDownLatch(parallelism)
+        val release = CountDownLatch(1)
+        repeat(parallelism) {
+            soft.dispatch(EmptyCoroutineContext, Runnable {
+                started.countDown()
+                release.await()
+            })
+        }
+        assertTrue(started.await(10, TimeUnit.SECONDS))
+
+        soft.adjustParallelism(1)
+        val extraStarted = CountDownLatch(1)
+        soft.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
+        assertTrue(
+            extraStarted.await(10, TimeUnit.SECONDS),
+            "adjustParallelism(1) should let one extra task run concurrently on the soft-limited view"
+        )
+
+        soft.adjustParallelism(-1)
+        release.countDown()
+    }
+
+    @Test
+    fun testIoLikeDispatcherAdjustParallelismByMinusOneShrinksBelowInitialParallelism() {
+        val parallelism = 2
+        val soft = softBlockingDispatcher(parallelism)
+
+        soft.adjustParallelism(-1)
+
+        val started = CountDownLatch(parallelism)
+        val release = CountDownLatch(1)
+        repeat(parallelism) {
+            soft.dispatch(EmptyCoroutineContext, Runnable {
+                started.countDown()
+                release.await()
+            })
+        }
+        assertFalse(
+            started.await(2, TimeUnit.SECONDS),
+            "adjustParallelism(-1) should have reduced concurrency below the initial parallelism"
+        )
+        assertEquals(1L, started.count)
+        release.countDown()
+    }
+}

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -178,6 +178,54 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         }
     }
 
+    @Test
+    fun testBatchSoftIncreaseStartsEveryRequiredQueuedWorker() {
+        val soft = softBlockingDispatcher(parallelism = 1)
+
+        val originalStarted = CountDownLatch(1)
+        val releaseOriginal = CountDownLatch(1)
+
+        val queuedStarted = CountDownLatch(2)
+        val releaseQueued = CountDownLatch(1)
+
+        try {
+            soft.dispatch(
+                EmptyCoroutineContext,
+                Runnable {
+                    originalStarted.countDown()
+                    releaseOriginal.await()
+                }
+            )
+
+            assertTrue(
+                originalStarted.await(10, TimeUnit.SECONDS)
+            )
+
+            repeat(2) {
+                soft.dispatch(
+                    EmptyCoroutineContext,
+                    Runnable {
+                        queuedStarted.countDown()
+                        releaseQueued.await()
+                    }
+                )
+            }
+
+            assertEquals(
+                2,
+                soft.tryAdjustParallelism(2)
+            )
+
+            assertTrue(
+                queuedStarted.await(2, TimeUnit.SECONDS),
+                "A +2 adjustment must start two queued workers. " +
+                    "Starting only one may leave a dependency cycle deadlocked."
+            )
+        } finally {
+            releaseOriginal.countDown()
+            releaseQueued.countDown()
+        }
+    }
 
     @Test
     fun testIoLikeDispatcherConcurrentAdjustParallelismNeverOverdraftsHeadroom() {

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -1,6 +1,7 @@
 package kotlinx.coroutines.scheduling
 
 import kotlinx.coroutines.internal.*
+import kotlinx.coroutines.testing.*
 import org.junit.Test
 import java.util.concurrent.*
 import kotlin.coroutines.*
@@ -103,11 +104,13 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
     }
 
     @Test
-    fun testIoLikeDispatcherAdjustParallelismByMinusOneShrinksBelowInitialParallelism() {
+    fun testIoLikeDispatcherAdjustParallelismByMinusOneCannotShrinkBelowInitialParallelism() {
         val parallelism = 2
         val soft = softBlockingDispatcher(parallelism)
 
-        assertEquals((-1).toByte(), soft.tryAdjustParallelism(-1), "a soft-limited view is free to shrink below its initial parallelism")
+        // A soft-limited view must never drop below its initial parallelism on its own: there is no
+        // outstanding compensation to reclaim, so this must be a no-op.
+        assertEquals(0.toByte(), soft.tryAdjustParallelism(-1), "a soft-limited view must not shrink below its initial parallelism")
 
         val started = CountDownLatch(parallelism)
         val release = CountDownLatch(1)
@@ -117,11 +120,50 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
                 release.await()
             })
         }
-        assertFalse(
-            started.await(2, TimeUnit.SECONDS),
-            "adjustParallelism(-1) should have reduced concurrency below the initial parallelism"
+        assertTrue(
+            started.await(10, TimeUnit.SECONDS),
+            "adjustParallelism(-1) without prior headroom must not reduce concurrency below the initial parallelism"
         )
-        assertEquals(1L, started.count)
         release.countDown()
+    }
+
+    /**
+     * Regression test for a race in [SoftLimitedDispatcher.tryAdjustParallelism]: the bounds check
+     * ("would this delta push totalParallelism below the allowed minimum?") and the update used to be
+     * two separate steps that were not atomic with respect to each other. Two concurrent callers could
+     * both read the same pre-update `totalParallelism`, both conclude the reclaim is within bounds, and
+     * both apply their delta - overshooting the limit even though each individual check looked valid.
+     *
+     * Here exactly one unit of headroom is granted, then two threads race to reclaim it with `-1`.
+     * Without a lock serializing check-and-update, both `-1` calls can occasionally succeed, which
+     * would shrink the dispatcher below its initial parallelism - something no single caller is allowed
+     * to do without a matching grant.
+     */
+    @Test
+    fun testIoLikeDispatcherConcurrentAdjustParallelismNeverOverdraftsHeadroom() {
+        val parallelism = 2
+        val soft = softBlockingDispatcher(parallelism)
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            repeat(10_000 * stressTestMultiplierSqrt) {
+                assertEquals(1.toByte(), soft.tryAdjustParallelism(1), "should always be able to grant a single unit of headroom")
+
+                val barrier = CyclicBarrier(2)
+                val futures = List(2) {
+                    executor.submit(Callable {
+                        barrier.await(10, TimeUnit.SECONDS)
+                        soft.tryAdjustParallelism(-1)
+                    })
+                }
+                val results = futures.map { it.get(10, TimeUnit.SECONDS) }
+
+                assertEquals(
+                    -1, results.sumOf { it.toInt() },
+                    "exactly one of the two concurrent reclaims should succeed since only one unit of headroom was granted, got $results"
+                )
+            }
+        } finally {
+            executor.shutdown()
+        }
     }
 }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -7,7 +7,7 @@ import kotlin.coroutines.*
 import kotlin.test.*
 
 /**
- * Exercises `CoroutineDispatcher.adjustParallelism(+1)` / `(-1)` at the dispatcher level (as opposed to
+ * Exercises `CoroutineDispatcher.tryAdjustParallelism(+1)` / `(-1)` at the dispatcher level (as opposed to
  * [CpuParallelismControlTest], which drives [CoroutineScheduler]'s increase/decrease methods directly), for
  * both flavors of dispatcher that implement [SoftLimitedParallelism]:
  *  - a plain [SchedulerCoroutineDispatcher] (what backs `Dispatchers.Default`)

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -31,7 +31,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         // All corePoolSize permits are held by the busy tasks above (which are still blocked on
         // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
         // new permit.
-        assertEquals(1, dispatcher.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
+        assertEquals(1.toByte(), dispatcher.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
         val extraStarted = CountDownLatch(1)
         dispatcher.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -39,7 +39,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently with the corePoolSize busy ones"
         )
 
-        assertEquals(-1, dispatcher.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
+        assertEquals((-1).toByte(), dispatcher.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
         release.countDown()
     }
 
@@ -49,8 +49,8 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         maxPoolSize = 64
         // tryAdjustParallelism(delta) increments/decrements one unit at a time internally; make sure it
         // does so exactly `delta` times rather than off by one in either direction.
-        assertEquals(3, dispatcher.tryAdjustParallelism(3), "adjustParallelism(3) should grant exactly 3 extra units of parallelism")
-        assertEquals(-3, dispatcher.tryAdjustParallelism(-3), "adjustParallelism(-3) should reclaim exactly the 3 units granted above")
+        assertEquals(3.toByte(), dispatcher.tryAdjustParallelism(3), "adjustParallelism(3) should grant exactly 3 extra units of parallelism")
+        assertEquals((-3).toByte(), dispatcher.tryAdjustParallelism(-3), "adjustParallelism(-3) should reclaim exactly the 3 units granted above")
     }
 
     @Test
@@ -58,7 +58,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         corePoolSize = 2
         // No matching adjustParallelism(1) beforehand -> zero legitimate headroom, so this must not
         // shrink the pool below corePoolSize.
-        assertEquals(0, dispatcher.tryAdjustParallelism(-1), "there is no outstanding compensation to reclaim, so nothing should be adjusted")
+        assertEquals(0.toByte(), dispatcher.tryAdjustParallelism(-1), "there is no outstanding compensation to reclaim, so nothing should be adjusted")
 
         val started = CountDownLatch(corePoolSize)
         val release = CountDownLatch(1)
@@ -90,7 +90,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         }
         assertTrue(started.await(10, TimeUnit.SECONDS))
 
-        assertEquals(1, soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
+        assertEquals(1.toByte(), soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
         val extraStarted = CountDownLatch(1)
         soft.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -98,7 +98,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently on the soft-limited view"
         )
 
-        assertEquals(-1, soft.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
+        assertEquals((-1).toByte(), soft.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
         release.countDown()
     }
 
@@ -107,7 +107,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         val parallelism = 2
         val soft = softBlockingDispatcher(parallelism)
 
-        assertEquals(-1, soft.tryAdjustParallelism(-1), "a soft-limited view is free to shrink below its initial parallelism")
+        assertEquals((-1).toByte(), soft.tryAdjustParallelism(-1), "a soft-limited view is free to shrink below its initial parallelism")
 
         val started = CountDownLatch(parallelism)
         val release = CountDownLatch(1)

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -90,6 +90,34 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         }
     }
 
+    @Test(timeout = 5_000L)
+    fun testDefaultLikeDispatcherHandlesExtremeAdjustmentsPromptly() {
+        corePoolSize = 1
+        maxPoolSize = 64
+
+        val increased = dispatcher.tryAdjustParallelism(Int.MAX_VALUE)
+
+        assertEquals(
+            MAX_OUTSTANDING_CPU_COMPENSATIONS,
+            increased,
+            "Int.MAX_VALUE should apply adjustments until the first failure"
+        )
+
+        val decreased = dispatcher.tryAdjustParallelism(Int.MIN_VALUE)
+
+        assertEquals(
+            -increased,
+            decreased,
+            "Int.MIN_VALUE should reclaim all available adjustments and stop at the first failure"
+        )
+
+        assertEquals(
+            0,
+            dispatcher.tryAdjustParallelism(-1),
+            "All outstanding adjustments should already be reclaimed"
+        )
+    }
+
     @Test
     fun testIoLikeDispatcherAdjustParallelismByOneLetsExtraTaskRunConcurrently() {
         val parallelism = 2

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -98,7 +98,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         val increased = dispatcher.tryAdjustParallelism(Int.MAX_VALUE)
 
         assertEquals(
-            MAX_OUTSTANDING_CPU_COMPENSATIONS,
+            maxPoolSize - corePoolSize,
             increased,
             "Int.MAX_VALUE should apply adjustments until the first failure"
         )

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -31,7 +31,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         // All corePoolSize permits are held by the busy tasks above (which are still blocked on
         // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
         // new permit.
-        dispatcher.tryAdjustParallelism(1)
+        assertEquals(1, dispatcher.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
         val extraStarted = CountDownLatch(1)
         dispatcher.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -39,8 +39,18 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently with the corePoolSize busy ones"
         )
 
-        dispatcher.tryAdjustParallelism(-1)
+        assertEquals(-1, dispatcher.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
         release.countDown()
+    }
+
+    @Test
+    fun testDefaultLikeDispatcherAdjustParallelismByMultipleUnitsGrantsExactlyThatMany() {
+        corePoolSize = 2
+        maxPoolSize = 64
+        // tryAdjustParallelism(delta) increments/decrements one unit at a time internally; make sure it
+        // does so exactly `delta` times rather than off by one in either direction.
+        assertEquals(3, dispatcher.tryAdjustParallelism(3), "adjustParallelism(3) should grant exactly 3 extra units of parallelism")
+        assertEquals(-3, dispatcher.tryAdjustParallelism(-3), "adjustParallelism(-3) should reclaim exactly the 3 units granted above")
     }
 
     @Test
@@ -48,7 +58,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         corePoolSize = 2
         // No matching adjustParallelism(1) beforehand -> zero legitimate headroom, so this must not
         // shrink the pool below corePoolSize.
-        dispatcher.tryAdjustParallelism(-1)
+        assertEquals(0, dispatcher.tryAdjustParallelism(-1), "there is no outstanding compensation to reclaim, so nothing should be adjusted")
 
         val started = CountDownLatch(corePoolSize)
         val release = CountDownLatch(1)
@@ -80,7 +90,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         }
         assertTrue(started.await(10, TimeUnit.SECONDS))
 
-        soft.tryAdjustParallelism(1)
+        assertEquals(1, soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
         val extraStarted = CountDownLatch(1)
         soft.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -88,7 +98,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently on the soft-limited view"
         )
 
-        soft.tryAdjustParallelism(-1)
+        assertEquals(-1, soft.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
         release.countDown()
     }
 
@@ -97,7 +107,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         val parallelism = 2
         val soft = softBlockingDispatcher(parallelism)
 
-        soft.tryAdjustParallelism(-1)
+        assertEquals(-1, soft.tryAdjustParallelism(-1), "a soft-limited view is free to shrink below its initial parallelism")
 
         val started = CountDownLatch(parallelism)
         val release = CountDownLatch(1)

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -34,7 +34,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
             // new permit.
             assertEquals(
-                1.toByte(),
+                1,
                 dispatcher.tryAdjustParallelism(1),
                 "a single unit of headroom should be granted in full"
             )
@@ -46,7 +46,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             )
 
             assertEquals(
-                (-1).toByte(),
+                -1,
                 dispatcher.tryAdjustParallelism(-1),
                 "the previously granted unit of headroom should be reclaimed in full"
             )
@@ -61,8 +61,8 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         maxPoolSize = 64
         // tryAdjustParallelism(delta) increments/decrements one unit at a time internally; make sure it
         // does so exactly `delta` times rather than off by one in either direction.
-        assertEquals(3.toByte(), dispatcher.tryAdjustParallelism(3), "adjustParallelism(3) should grant exactly 3 extra units of parallelism")
-        assertEquals((-3).toByte(), dispatcher.tryAdjustParallelism(-3), "adjustParallelism(-3) should reclaim exactly the 3 units granted above")
+        assertEquals(3, dispatcher.tryAdjustParallelism(3), "adjustParallelism(3) should grant exactly 3 extra units of parallelism")
+        assertEquals(-3, dispatcher.tryAdjustParallelism(-3), "adjustParallelism(-3) should reclaim exactly the 3 units granted above")
     }
 
     @Test
@@ -70,7 +70,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         corePoolSize = 2
         // No matching adjustParallelism(1) beforehand -> zero legitimate headroom, so this must not
         // shrink the pool below corePoolSize.
-        assertEquals(0.toByte(), dispatcher.tryAdjustParallelism(-1), "there is no outstanding compensation to reclaim, so nothing should be adjusted")
+        assertEquals(0, dispatcher.tryAdjustParallelism(-1), "there is no outstanding compensation to reclaim, so nothing should be adjusted")
 
         val started = CountDownLatch(corePoolSize)
         val release = CountDownLatch(1)
@@ -105,7 +105,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         }
         assertTrue(started.await(10, TimeUnit.SECONDS))
 
-        assertEquals(1.toByte(), soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
+        assertEquals(1, soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
         val extraStarted = CountDownLatch(1)
         soft.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -113,7 +113,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently on the soft-limited view"
         )
 
-        assertEquals((-1).toByte(), soft.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
+        assertEquals(-1, soft.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
         release.countDown()
     }
 
@@ -124,7 +124,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
 
         // A soft-limited view must never drop below its initial parallelism on its own: there is no
         // outstanding compensation to reclaim, so this must be a no-op.
-        assertEquals(0.toByte(), soft.tryAdjustParallelism(-1), "a soft-limited view must not shrink below its initial parallelism")
+        assertEquals(0, soft.tryAdjustParallelism(-1), "a soft-limited view must not shrink below its initial parallelism")
 
         val started = CountDownLatch(parallelism)
         val release = CountDownLatch(1)
@@ -165,7 +165,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
                 "sanity check: the second task should still be queued, since no permit was available for it"
             )
 
-            assertEquals(1.toByte(), soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
+            assertEquals(1, soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
             // The sole worker above is still stuck on release.await() (simulating a deadlocked task), so the
             // only way the already-queued task can start now is if adjustParallelism(1) itself kicks the queue.
             assertTrue(
@@ -186,7 +186,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         val executor = Executors.newFixedThreadPool(2)
         try {
             repeat(10_000 * stressTestMultiplierSqrt) {
-                assertEquals(1.toByte(), soft.tryAdjustParallelism(1), "should always be able to grant a single unit of headroom")
+                assertEquals(1, soft.tryAdjustParallelism(1), "should always be able to grant a single unit of headroom")
 
                 val barrier = CyclicBarrier(2)
                 val futures = List(2) {

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -31,7 +31,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         // All corePoolSize permits are held by the busy tasks above (which are still blocked on
         // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
         // new permit.
-        dispatcher.adjustParallelism(1)
+        dispatcher.tryAdjustParallelism(1)
         val extraStarted = CountDownLatch(1)
         dispatcher.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -39,7 +39,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently with the corePoolSize busy ones"
         )
 
-        dispatcher.adjustParallelism(-1)
+        dispatcher.tryAdjustParallelism(-1)
         release.countDown()
     }
 
@@ -48,7 +48,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         corePoolSize = 2
         // No matching adjustParallelism(1) beforehand -> zero legitimate headroom, so this must not
         // shrink the pool below corePoolSize.
-        dispatcher.adjustParallelism(-1)
+        dispatcher.tryAdjustParallelism(-1)
 
         val started = CountDownLatch(corePoolSize)
         val release = CountDownLatch(1)
@@ -80,7 +80,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         }
         assertTrue(started.await(10, TimeUnit.SECONDS))
 
-        soft.adjustParallelism(1)
+        soft.tryAdjustParallelism(1)
         val extraStarted = CountDownLatch(1)
         soft.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
         assertTrue(
@@ -88,7 +88,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
             "adjustParallelism(1) should let one extra task run concurrently on the soft-limited view"
         )
 
-        soft.adjustParallelism(-1)
+        soft.tryAdjustParallelism(-1)
         release.countDown()
     }
 
@@ -97,7 +97,7 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         val parallelism = 2
         val soft = softBlockingDispatcher(parallelism)
 
-        soft.adjustParallelism(-1)
+        soft.tryAdjustParallelism(-1)
 
         val started = CountDownLatch(parallelism)
         val release = CountDownLatch(1)

--- a/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/DispatcherParallelismAdjustmentTest.kt
@@ -21,27 +21,38 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         corePoolSize = 2
         val started = CountDownLatch(corePoolSize)
         val release = CountDownLatch(1)
-        repeat(corePoolSize) {
-            dispatcher.dispatch(EmptyCoroutineContext, Runnable {
-                started.countDown()
-                release.await()
-            })
+        try {
+            repeat(corePoolSize) {
+                dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+                    started.countDown()
+                    release.await()
+                })
+            }
+            assertTrue(started.await(10, TimeUnit.SECONDS))
+
+            // All corePoolSize permits are held by the busy tasks above (which are still blocked on
+            // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
+            // new permit.
+            assertEquals(
+                1.toByte(),
+                dispatcher.tryAdjustParallelism(1),
+                "a single unit of headroom should be granted in full"
+            )
+            val extraStarted = CountDownLatch(1)
+            dispatcher.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
+            assertTrue(
+                extraStarted.await(10, TimeUnit.SECONDS),
+                "adjustParallelism(1) should let one extra task run concurrently with the corePoolSize busy ones"
+            )
+
+            assertEquals(
+                (-1).toByte(),
+                dispatcher.tryAdjustParallelism(-1),
+                "the previously granted unit of headroom should be reclaimed in full"
+            )
+        } finally {
+            release.countDown()
         }
-        assertTrue(started.await(10, TimeUnit.SECONDS))
-
-        // All corePoolSize permits are held by the busy tasks above (which are still blocked on
-        // release), so this extra task can only start if adjustParallelism(1) genuinely grants a
-        // new permit.
-        assertEquals(1.toByte(), dispatcher.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
-        val extraStarted = CountDownLatch(1)
-        dispatcher.dispatch(EmptyCoroutineContext, Runnable { extraStarted.countDown() })
-        assertTrue(
-            extraStarted.await(10, TimeUnit.SECONDS),
-            "adjustParallelism(1) should let one extra task run concurrently with the corePoolSize busy ones"
-        )
-
-        assertEquals((-1).toByte(), dispatcher.tryAdjustParallelism(-1), "the previously granted unit of headroom should be reclaimed in full")
-        release.countDown()
     }
 
     @Test
@@ -63,17 +74,20 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
 
         val started = CountDownLatch(corePoolSize)
         val release = CountDownLatch(1)
-        repeat(corePoolSize) {
-            dispatcher.dispatch(EmptyCoroutineContext, Runnable {
-                started.countDown()
-                release.await()
-            })
+        try {
+            repeat(corePoolSize) {
+                dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+                    started.countDown()
+                    release.await()
+                })
+            }
+            assertTrue(
+                started.await(10, TimeUnit.SECONDS),
+                "adjustParallelism(-1) without a matching increase must not shrink the pool below corePoolSize"
+            )
+        } finally {
+            release.countDown()
         }
-        assertTrue(
-            started.await(10, TimeUnit.SECONDS),
-            "adjustParallelism(-1) without a matching increase must not shrink the pool below corePoolSize"
-        )
-        release.countDown()
     }
 
     @Test
@@ -127,18 +141,44 @@ class DispatcherParallelismAdjustmentTest : SchedulerTestBase() {
         release.countDown()
     }
 
-    /**
-     * Regression test for a race in [SoftLimitedDispatcher.tryAdjustParallelism]: the bounds check
-     * ("would this delta push totalParallelism below the allowed minimum?") and the update used to be
-     * two separate steps that were not atomic with respect to each other. Two concurrent callers could
-     * both read the same pre-update `totalParallelism`, both conclude the reclaim is within bounds, and
-     * both apply their delta - overshooting the limit even though each individual check looked valid.
-     *
-     * Here exactly one unit of headroom is granted, then two threads race to reclaim it with `-1`.
-     * Without a lock serializing check-and-update, both `-1` calls can occasionally succeed, which
-     * would shrink the dispatcher below its initial parallelism - something no single caller is allowed
-     * to do without a matching grant.
-     */
+    @Test
+    fun testIoLikeDispatcherAdjustParallelismByOneStartsAlreadyQueuedWork() {
+        val parallelism = 1
+        val soft = softBlockingDispatcher(parallelism)
+
+        val started = CountDownLatch(parallelism)
+        val release = CountDownLatch(1)
+        try {
+            repeat(parallelism) {
+                soft.dispatch(EmptyCoroutineContext, Runnable {
+                    started.countDown()
+                    release.await()
+                })
+            }
+            assertTrue(started.await(10, TimeUnit.SECONDS))
+
+            // No permit is free for this task, so it sits in the internal queue instead of running.
+            val queuedStarted = CountDownLatch(1)
+            soft.dispatch(EmptyCoroutineContext, Runnable { queuedStarted.countDown() })
+            assertFalse(
+                queuedStarted.await(500, TimeUnit.MILLISECONDS),
+                "sanity check: the second task should still be queued, since no permit was available for it"
+            )
+
+            assertEquals(1.toByte(), soft.tryAdjustParallelism(1), "a single unit of headroom should be granted in full")
+            // The sole worker above is still stuck on release.await() (simulating a deadlocked task), so the
+            // only way the already-queued task can start now is if adjustParallelism(1) itself kicks the queue.
+            assertTrue(
+                queuedStarted.await(1000, TimeUnit.MILLISECONDS),
+                "adjustParallelism(1) must start already-queued work -- otherwise it cannot unblock work stuck " +
+                    "behind a task that will never return on its own, defeating deadlock recovery"
+            )
+        } finally {
+            release.countDown()
+        }
+    }
+
+
     @Test
     fun testIoLikeDispatcherConcurrentAdjustParallelismNeverOverdraftsHeadroom() {
         val parallelism = 2

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -140,7 +140,7 @@ internal fun SchedulerCoroutineDispatcher.softBlocking(parallelism: Int = 16): C
             return this@softBlocking.softLimitedParallelism(parallelism, name)
         }
 
-        override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
+        override fun tryAdjustParallelism(parallelismDelta: Int): Int {
             return this@softBlocking.tryAdjustParallelism(parallelismDelta)
         }
     }.softLimitedParallelism(parallelism, null)

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -140,8 +140,8 @@ internal fun SchedulerCoroutineDispatcher.softBlocking(parallelism: Int = 16): C
             return this@softBlocking.softLimitedParallelism(parallelism, name)
         }
 
-        override fun adjustParallelism(parallelism: Int) {
-            return this@softBlocking.adjustParallelism(parallelism)
+        override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+            return this@softBlocking.tryAdjustParallelism(parallelismDelta)
         }
     }.softLimitedParallelism(parallelism, null)
 }

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -140,7 +140,7 @@ internal fun SchedulerCoroutineDispatcher.softBlocking(parallelism: Int = 16): C
             return this@softBlocking.softLimitedParallelism(parallelism, name)
         }
 
-        override fun tryAdjustParallelism(parallelismDelta: Int): Int {
+        override fun tryAdjustParallelism(parallelismDelta: Byte): Byte {
             return this@softBlocking.tryAdjustParallelism(parallelismDelta)
         }
     }.softLimitedParallelism(parallelism, null)

--- a/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
+++ b/kotlinx-coroutines-core/jvm/test/scheduling/SchedulerTestBase.kt
@@ -139,5 +139,9 @@ internal fun SchedulerCoroutineDispatcher.softBlocking(parallelism: Int = 16): C
         override fun softLimitedParallelism(parallelism: Int, name: String?): CoroutineDispatcher {
             return this@softBlocking.softLimitedParallelism(parallelism, name)
         }
+
+        override fun adjustParallelism(parallelism: Int) {
+            return this@softBlocking.adjustParallelism(parallelism)
+        }
     }.softLimitedParallelism(parallelism, null)
 }


### PR DESCRIPTION
Add a `tryAdjustParallelism(parallelismDelta: Int): Int` API that allows dynamically increasing or decreasing the parallelism limit of `Dispatchers.Default`, `Dispatchers.IO`, and soft-limited dispatchers created via `softLimitedParallelism`.
Changes:

* Add `tryAdjustParallelism` to the `SoftLimitedParallelism` interface and implement it in `SoftLimitedDispatcher` and `NamedSoftParallelismDispatcher`
* Add `tryIncreaseCpuParallelism()` / `tryDecreaseCpuParallelism()` to `CoroutineScheduler`, guarded by a `compensationLock` and bounded by `MAX_OUTSTANDING_CPU_COMPENSATIONS`
* Implement the adjustment in `Dispatcher.kt` for `UnlimitedIoScheduler` (no-op) and the default scheduler-backed dispatcher
* Expose `tryAdjustParallelism` via the `IntellijCoroutines` facade in `intellij.kt`
* Add tests: `CpuParallelismControlTest`, `DispatcherParallelismAdjustmentTest`

Notes:

* Adjustment is best-effort: the actual delta applied may be less than requested (or zero) and is returned to the caller
* The parallelism cannot be decreased below the initial `parallelism`